### PR TITLE
[MJARSIGNER-48] Mark verify and sign Mojos thread safe

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -48,7 +48,7 @@ import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
  * @author <a href="cs@schulte.it">Christian Schulte</a>
  * @since 1.0
  */
-@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class JarsignerSignMojo extends AbstractJarsignerMojo {
 
     /**

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojo.java
@@ -38,7 +38,7 @@ import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
  * @author <a href="cs@schulte.it">Christian Schulte</a>
  * @since 1.0
  */
-@Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY)
+@Mojo(name = "verify", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class JarsignerVerifyMojo extends AbstractJarsignerMojo {
 
     /**


### PR DESCRIPTION
Implements MJARSIGNER-48.

The Mojos are safe in the context of Maven 3 parallel builds. However running multiple Maven builds on the same signables might cause problems, but this is not something that should be covered.