### PR TITLE
[MJARSIGNER-41] Retry and delay feature when signing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@ under the License.
 
   <properties>
     <mavenVersion>3.2.5</mavenVersion>
+    <jacocoVersion>0.8.11</jacocoVersion>
     <project.build.outputTimestamp>2020-04-07T21:04:00Z</project.build.outputTimestamp>
   </properties>
 
@@ -128,6 +129,25 @@ under the License.
       <artifactId>maven-jarsigner</artifactId>
       <version>3.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Used for test cases to perform simple logging without any SLF4J warning -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -149,6 +169,27 @@ under the License.
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacocoVersion}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -20,16 +20,20 @@ package org.apache.maven.plugins.jarsigner;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerRequest;
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
 import org.apache.maven.shared.jarsigner.JarSignerUtil;
 import org.apache.maven.shared.utils.StringUtils;
 import org.apache.maven.shared.utils.cli.Commandline;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolException;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
 
 /**
  * Signs a project artifact and attachments using jarsigner.
@@ -90,6 +94,33 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     @Parameter(property = "jarsigner.certchain", readonly = true, required = false)
     private File certchain;
 
+    /**
+     * How many times to try to sign a jar (assuming each previous attempt is a failure). This option may be desirable
+     * if any network operations are used during signing, for example using a Time Stamp Authority or network based
+     * PKCS11 HSM solution for storing code signing keys.
+     *
+     * The default value of 1 indicates that no retries should be made.
+     *
+     * @since 3.1.0
+     */
+    @Parameter(property = "jarsigner.maxTries", defaultValue = "1")
+    private int maxTries;
+
+    /**
+     * Maximum delay, in seconds, to wait after a failed attempt before re-trying. The delay after a failed attempt
+     * follows an exponential backoff strategy, with increasing delay times.
+     *
+     * @since 3.1.0
+     */
+    @Parameter(property = "jarsigner.maxRetryDelaySeconds", defaultValue = "0")
+    private int maxRetryDelaySeconds;
+
+    /** Current WaitStrategy, to allow for sleeping after a signing failure. */
+    private WaitStrategy waitStrategy = this::defaultWaitStrategy;
+
+    /** Exponent limit for exponential wait after failure function. 2^20 = 1048576 sec ~= 12 days. */
+    private static final int MAX_WAIT_EXPONENT_ATTEMPT = 20;
+
     @Override
     protected String getCommandlineInfo(final Commandline commandLine) {
         String commandLineInfo = commandLine != null ? commandLine.toString() : null;
@@ -112,9 +143,25 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         }
     }
 
+    @Override
+    protected void validateParameters() throws MojoExecutionException {
+        super.validateParameters();
+
+        if (maxTries < 1) {
+            getLog().warn(getMessage("invalidMaxTries", maxTries));
+            maxTries = 1;
+        }
+
+        if (maxRetryDelaySeconds < 0) {
+            getLog().warn(getMessage("invalidMaxRetryDelaySeconds", maxRetryDelaySeconds));
+            maxRetryDelaySeconds = 0;
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
+    @Override
     protected JarSignerRequest createRequest(File archive) throws MojoExecutionException {
         JarSignerSignRequest request = new JarSignerSignRequest();
         request.setSigfile(sigfile);
@@ -125,5 +172,77 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         // Special handling for passwords through the Maven Security Dispatcher
         request.setKeypass(decrypt(keypass));
         return request;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Will retry signing up to maxTries times if it fails.
+     *
+     * @throws MojoExecutionException If all signing attempts fail.
+     */
+    @Override
+    protected void executeJarSigner(JarSigner jarSigner, JarSignerRequest request)
+            throws JavaToolException, MojoExecutionException {
+        for (int attempt = 0; attempt < maxTries; attempt++) {
+            JavaToolResult result = jarSigner.execute(request);
+            int resultCode = result.getExitCode();
+            Commandline commandLine = result.getCommandline();
+            if (resultCode == 0) {
+                return;
+            }
+            if (attempt < maxTries - 1) { // If not last attempt
+                waitStrategy.waitAfterFailure(attempt, Duration.ofSeconds(maxRetryDelaySeconds));
+            } else {
+                // Last attempt failed, use this failure as resulting failure
+                throw new MojoExecutionException(getMessage("failure", getCommandlineInfo(commandLine), resultCode));
+            }
+        }
+    }
+
+    /** Set current WaitStrategy. Package private for testing. */
+    void setWaitStrategy(WaitStrategy waitStrategy) {
+        this.waitStrategy = waitStrategy;
+    }
+
+    /** Wait/sleep after a signing failure before the next re-try should happen. */
+    @FunctionalInterface
+    interface WaitStrategy {
+        /**
+         * Will be called after a signing failure, if a re-try is about to happen. May as a side effect sleep current
+         * thread for some time.
+         *
+         * @param attempt the attempt number (0 is the first)
+         * @param maxRetryDelay the maximum duration to sleep (may be zero)
+         * @throws MojoExecutionException if the sleep was interrupted
+         */
+        void waitAfterFailure(int attempt, Duration maxRetryDelay) throws MojoExecutionException;
+    }
+
+    private void defaultWaitStrategy(int attempt, Duration maxRetryDelay) throws MojoExecutionException {
+        waitAfterFailure(attempt, maxRetryDelay, Thread::sleep);
+    }
+
+    /** Thread.sleep(long millis) interface to make testing easier */
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+
+    /** Package private for testing */
+    void waitAfterFailure(int attempt, Duration maxRetryDelay, Sleeper sleeper) throws MojoExecutionException {
+        // Use attempt as exponent in the exponential function, but limit it to avoid too big values.
+        int exponentAttempt = Math.min(attempt, MAX_WAIT_EXPONENT_ATTEMPT);
+        long delayMillis = (long) (Duration.ofSeconds(1).toMillis() * Math.pow(2, exponentAttempt));
+        delayMillis = Math.min(delayMillis, maxRetryDelay.toMillis());
+        if (delayMillis > 0) {
+            getLog().info("Sleeping after failed attempt for " + (delayMillis / 1000) + " seconds...");
+            try {
+                sleeper.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MojoExecutionException("Thread interrupted while waiting after failure", e);
+            }
+        }
     }
 }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojo.java
@@ -25,9 +25,12 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerRequest;
 import org.apache.maven.shared.jarsigner.JarSignerUtil;
 import org.apache.maven.shared.jarsigner.JarSignerVerifyRequest;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolException;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
 
 /**
  * Checks the signatures of a project artifact and attachments using jarsigner.
@@ -58,6 +61,7 @@ public class JarsignerVerifyMojo extends AbstractJarsignerMojo {
     /**
      * {@inheritDoc}
      */
+    @Override
     protected JarSignerRequest createRequest(File archive) {
         JarSignerVerifyRequest request = new JarSignerVerifyRequest();
         request.setCerts(certs);
@@ -84,6 +88,17 @@ public class JarsignerVerifyMojo extends AbstractJarsignerMojo {
                 // fails, archive must be signed
                 throw new MojoExecutionException(getMessage("archiveNotSigned", archive));
             }
+        }
+    }
+
+    @Override
+    protected void executeJarSigner(JarSigner jarSigner, JarSignerRequest request)
+            throws JavaToolException, MojoExecutionException {
+        JavaToolResult result = jarSigner.execute(request);
+        int resultCode = result.getExitCode();
+        if (resultCode != 0) {
+            throw new MojoExecutionException(
+                    getMessage("failure", getCommandlineInfo(result.getCommandline()), resultCode));
         }
     }
 }

--- a/src/main/resources/jarsigner.properties
+++ b/src/main/resources/jarsigner.properties
@@ -24,3 +24,5 @@ command = ''{0}''
 commandLineException = Failed executing ''{0}''
 failure = Failed executing ''{0}'' - exitcode {1,number}
 archiveNotSigned = Archive ''{0}'' is not signed
+invalidMaxTries = Invalid maxTries value. Was ''{0}'' but should be >= 1
+invalidMaxRetryDelaySeconds = Invalid maxRetryDelaySeconds value. Was ''{0}'' but should be >= 0

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.jarsigner.JarsignerSignMojo.Sleeper;
+import org.apache.maven.plugins.jarsigner.JarsignerSignMojo.WaitStrategy;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.jarsigner.JarSigner;
+import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JarsignerSignMojoRetryTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Locale originalLocale;
+    private MavenProject project = mock(MavenProject.class);
+    private JarSigner jarSigner = mock(JarSigner.class);
+    private WaitStrategy waitStrategy = mock(WaitStrategy.class);
+    private File dummyMavenProjectDir;
+    private Map<String, String> configuration = new LinkedHashMap<>();
+    private Log log;
+    private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
+
+    @Before
+    public void setUp() throws Exception {
+        originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
+        dummyMavenProjectDir = folder.newFolder("dummy-project");
+        mojoTestCreator = new MojoTestCreator<JarsignerSignMojo>(
+                JarsignerSignMojo.class, project, dummyMavenProjectDir, jarSigner);
+        log = mock(Log.class);
+        mojoTestCreator.setLog(log);
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(originalLocale);
+    }
+
+    @Test
+    public void testSignSuccessOnFirst() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("maxTries", "1");
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner)
+                .execute(argThat(request -> request.getArchive().getPath().endsWith("my-project.jar")));
+        verify(waitStrategy, times(0)).waitAfterFailure(0, Duration.ofSeconds(0));
+    }
+
+    @Test
+    public void testSignFailureOnFirst() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_ERROR);
+        configuration.put("maxTries", "1");
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+        assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+        verify(jarSigner, times(1)).execute(any());
+        verify(waitStrategy, times(0)).waitAfterFailure(0, Duration.ofSeconds(0));
+    }
+
+    @Test
+    public void testSignFailureOnFirstSuccessOnSecond() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class)))
+                .thenReturn(RESULT_ERROR)
+                .thenReturn(RESULT_OK);
+        configuration.put("maxTries", "2");
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner, times(2)).execute(any());
+        verify(waitStrategy, times(1)).waitAfterFailure(0, Duration.ofSeconds(0));
+    }
+
+    @Test
+    public void testSignFailureOnFirstFailureOnSecond() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class)))
+                .thenReturn(RESULT_ERROR)
+                .thenReturn(RESULT_ERROR);
+        configuration.put("maxTries", "2");
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+        assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+        verify(jarSigner, times(2)).execute(any());
+        verify(waitStrategy, times(1)).waitAfterFailure(0, Duration.ofSeconds(0));
+    }
+
+    @Test
+    public void testInvalidMaxTries_zero() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_ERROR);
+
+        configuration.put("maxTries", "0"); // Setting an "invalid" value
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+
+        verify(jarSigner, times(1)).execute(any()); // Should have tried exactly one time, regardless of invalid value
+        verify(log).warn(contains("Invalid maxTries"));
+        verify(log).warn(contains("0"));
+    }
+
+    @Test
+    public void testInvalidMaxTries_negative() throws Exception {
+        // Make result ok, to make this test check more things (compared to testInvalidMaxTries_zero())
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        configuration.put("maxTries", "-2"); // Setting an "invalid" value
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner, times(1)).execute(any()); // Should have tried exactly one time, regardless of invalid value
+        verify(log).warn(contains("Invalid maxTries"));
+        verify(log).warn(contains("-2"));
+    }
+
+    @Test
+    public void testMaxRetryDelaySeconds() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class)))
+                .thenReturn(RESULT_ERROR)
+                .thenReturn(RESULT_ERROR)
+                .thenReturn(RESULT_OK);
+
+        configuration.put("maxTries", "3");
+        configuration.put("maxRetryDelaySeconds", "30");
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(waitStrategy, times(1)).waitAfterFailure(0, Duration.ofSeconds(30));
+        verify(waitStrategy, times(1)).waitAfterFailure(1, Duration.ofSeconds(30));
+    }
+
+    @Test
+    public void testInvalidMaxRetryDelaySeconds_negative() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class)))
+                .thenReturn(RESULT_ERROR)
+                .thenReturn(RESULT_OK);
+
+        configuration.put("maxTries", "10");
+        configuration.put("maxRetryDelaySeconds", "-5"); // Setting an "invalid" value
+        mojoTestCreator.setWaitStrategy(waitStrategy);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(waitStrategy).waitAfterFailure(0, Duration.ofSeconds(0));
+        verify(jarSigner, times(2)).execute(any());
+        verify(log).warn(contains("Invalid maxRetryDelaySeconds"));
+        verify(log).warn(contains("-5"));
+    }
+
+    @Test
+    public void testDefaultWaitStrategy() throws Exception {
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        long NO_SLEEP_VALUE = 42_001;
+        // Storage of the most recent sleep value
+        AtomicLong sleepValue = new AtomicLong(NO_SLEEP_VALUE);
+        Sleeper sleeper = value -> sleepValue.set(value);
+
+        mojo.waitAfterFailure(0, Duration.ofSeconds(0), sleeper);
+        assertEquals(NO_SLEEP_VALUE, sleepValue.get());
+
+        mojo.waitAfterFailure(1, Duration.ofSeconds(0), sleeper);
+        assertEquals(NO_SLEEP_VALUE, sleepValue.get());
+
+        mojo.waitAfterFailure(0, Duration.ofSeconds(1), sleeper);
+        assertEquals(1000, sleepValue.get());
+        verify(log).info(contains("for 1 seconds"));
+
+        mojo.waitAfterFailure(1, Duration.ofSeconds(1), sleeper);
+        assertEquals(1000, sleepValue.get());
+        mojo.waitAfterFailure(2, Duration.ofSeconds(1), sleeper);
+        assertEquals(1000, sleepValue.get());
+
+        mojo.waitAfterFailure(3, Duration.ofSeconds(100), sleeper);
+        assertEquals(8000, sleepValue.get());
+
+        mojo.waitAfterFailure(Integer.MAX_VALUE, Duration.ofSeconds(100), sleeper);
+        assertEquals(100_000, sleepValue.get());
+
+        sleepValue.set(NO_SLEEP_VALUE); // "reset" sleep value
+        mojo.waitAfterFailure(Integer.MIN_VALUE, Duration.ofSeconds(100), sleeper);
+        // Make sure sleep has not been invoked, should be the "reset" value
+        assertEquals(NO_SLEEP_VALUE, sleepValue.get());
+
+        // Testing the attempt limit used in exponential function. Will return a odd value (2^20).
+        mojo.waitAfterFailure(10000, Duration.ofDays(356), sleeper);
+        assertEquals(Duration.ofSeconds(1048576).toMillis(), sleepValue.get());
+        // Testing of attempt limit, when using a smaller maxRetryDelay
+        mojo.waitAfterFailure(10000, Duration.ofDays(1), sleeper);
+        assertEquals(Duration.ofDays(1).toMillis(), sleepValue.get());
+
+        Sleeper iterruptedSleeper = value -> {
+            throw new InterruptedException("Thread was interrupted while sleeping.");
+        };
+        MojoExecutionException mojoException = assertThrows(MojoExecutionException.class, () -> {
+            mojo.waitAfterFailure(0, Duration.ofSeconds(10), iterruptedSleeper);
+        });
+        assertThat(mojoException.getMessage(), containsString("interrupted while waiting after failure"));
+    }
+
+    /** Check that the error returned from a re-try scenario where all execution fails is the "correct" error */
+    @Test
+    public void testLastErrorReturned() throws Exception {
+        JavaToolResult lastError = new JavaToolResult();
+        lastError.setExitCode(42); // The exit code of the last jarsigner execution
+        lastError.setExecutionException(null);
+        lastError.setCommandline(RESULT_ERROR.getCommandline());
+
+        when(jarSigner.execute(any(JarSignerSignRequest.class)))
+                .thenReturn(RESULT_ERROR)
+                .thenReturn(lastError);
+
+        configuration.put("maxTries", "5");
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        MojoExecutionException mojoException = assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+
+        // Make sure that the last error exit code is present
+        assertThat(mojoException.getMessage(), containsString(String.valueOf(42)));
+        // Make sure that the first error exit code is not present
+        assertThat(mojoException.getMessage(), not(containsString(String.valueOf(1))));
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.jarsigner.JarSigner;
+import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+import org.apache.maven.shared.jarsigner.JarSignerUtil;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolException;
+import org.apache.maven.toolchain.Toolchain;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.hamcrest.MockitoHamcrest;
+
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.everyItem;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JarsignerSignMojoTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private MavenProject project = mock(MavenProject.class);
+    private JarSigner jarSigner = mock(JarSigner.class);
+    private File projectDir;
+    private Map<String, String> configuration = new LinkedHashMap<>();
+    private Log log;
+    private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
+
+    @Before
+    public void setUp() throws Exception {
+        projectDir = folder.newFolder("dummy-project");
+        mojoTestCreator =
+                new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
+        log = mock(Log.class);
+        mojoTestCreator.setLog(log);
+    }
+
+    /** Standard Java project with nothing special configured */
+    @Test
+    public void testStandardJavaProject() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        ArgumentCaptor<JarSignerSignRequest> requestArgument = ArgumentCaptor.forClass(JarSignerSignRequest.class);
+        verify(jarSigner).execute(requestArgument.capture());
+        JarSignerSignRequest request = requestArgument.getValue();
+
+        assertFalse(request.isVerbose());
+        assertNull(request.getKeystore());
+        assertNull(request.getStoretype());
+        assertNull(request.getStorepass());
+        assertNull(request.getAlias());
+        assertNull(request.getProviderName());
+        assertNull(request.getProviderClass());
+        assertNull(request.getProviderArg());
+        assertNull(request.getMaxMemory());
+        assertThat(request.getArguments()[0], startsWith("-J-Dfile.encoding="));
+        assertEquals(projectDir, request.getWorkingDirectory());
+        assertEquals(mainArtifact.getFile(), request.getArchive());
+        assertFalse(request.isProtectedAuthenticationPath());
+
+        assertNull(request.getKeypass());
+        assertNull(request.getSigfile());
+        assertNull(request.getTsaLocation());
+        assertNull(request.getTsaAlias());
+        assertNull(request.getSignedjar()); // Current JarsignerSignMojo does not have support for this parameter.
+        assertNull(request.getCertchain());
+    }
+
+    /** When jarsigner command invocation returns a non-zero exit code  */
+    @Test
+    public void testJarsignerNonZeroExitCode() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_ERROR);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        MojoExecutionException mojoException = assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+        assertThat(mojoException.getMessage(), containsString(String.valueOf(RESULT_ERROR.getExitCode())));
+        assertThat(
+                mojoException.getMessage(),
+                containsString(RESULT_ERROR.getCommandline().toString()));
+    }
+
+    /** When JavaTool throws an exception on execute() (when executing jarsigner). */
+    @Test
+    public void testJarsignerFailedToExecute() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenThrow(new JavaToolException("test failure"));
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        MojoExecutionException mojoException = assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+        assertThat(mojoException.getMessage(), containsString("test failure"));
+    }
+
+    /** Standard POM project with nothing special configured */
+    @Test
+    public void testStandardPOMProject() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createPomArtifact(projectDir, "my-project.pom");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner, times(0)).execute(any()); // Should not try to sign anything
+    }
+
+    /** Normal Java project, but avoid to process the main artifact (processMainArtifact to false) */
+    @Test
+    public void testDontProcessMainArtifact() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        configuration.put("processMainArtifact", "false");
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner, times(0)).execute(any()); // Should not try to sign anything
+    }
+
+    /** Make sure that when skip is configured the Mojo will not process anything */
+    @Test
+    public void testSkip() throws Exception {
+        when(project.getArtifact()).thenThrow(new AssertionError("Code should not try to get any artifacts"));
+        configuration.put("skip", "true");
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner, times(0)).execute(any()); // Should not try to sign anything
+    }
+
+    /** Only process the specified archive, don't process the main artifact nor the attached. */
+    @Test
+    public void testArchive() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        File archiveFile = TestArtifacts.createDummyZipFile(new File(projectDir, "archive.jar"));
+        configuration.put("archive", archiveFile.getPath());
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        // Make sure only the jar pointed by "archive" has been processed, but not the main artifact
+        verify(jarSigner, times(0)).execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("my-project.jar")));
+        verify(jarSigner, times(1)).execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("archive.jar")));
+    }
+
+    /** Test that it is possible to disable processing of attached artifacts */
+    @Test
+    public void testDontProcessAttachedArtifacts() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        configuration.put("processAttachedArtifacts", "false");
+
+        when(project.getAttachedArtifacts())
+                .thenReturn(Arrays.asList(TestArtifacts.createJarArtifact(
+                        projectDir, "my-project-sources.jar", "sources", "java-source")));
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        // Make sure that only the main artifact has been processed, but not the attached artifact
+        verify(jarSigner, times(1)).execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("my-project.jar")));
+        verify(jarSigner, times(0))
+                .execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("my-project-sources.jar")));
+    }
+
+    /** A Java project with 3 types of artifacts: main, javadoc and sources */
+    @Test
+    public void testJavaProjectWithSourcesAndJavadoc() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(project.getAttachedArtifacts())
+                .thenReturn(Arrays.asList(
+                        TestArtifacts.createJarArtifact(projectDir, "my-project-sources.jar", "sources", "java-source"),
+                        TestArtifacts.createJarArtifact(projectDir, "my-project-javadoc.jar", "javadoc", "javadoc")));
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        ArgumentCaptor<JarSignerSignRequest> requestArgument = ArgumentCaptor.forClass(JarSignerSignRequest.class);
+        verify(jarSigner, times(3)).execute(requestArgument.capture());
+
+        List<JarSignerSignRequest> requests = requestArgument.getAllValues();
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("my-project.jar")));
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("my-project-sources.jar")));
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("my-project-javadoc.jar")));
+    }
+
+    /**
+     * Set most possible documented parameter (that does not interfere too much with testing of other parameters). See
+     * Optional Parameters in site documentation.
+     */
+    @Test
+    public void testBig() throws Exception {
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+
+        when(project.getAttachedArtifacts())
+                .thenReturn(Arrays.asList(
+                        TestArtifacts.createJarArtifact(projectDir, "my-project-sources.jar", "sources"),
+                        TestArtifacts.createJarArtifact(projectDir, "my-project-javadoc.jar", "javadoc"),
+                        TestArtifacts.createJarArtifact(
+                                projectDir, "my-project-included_and_excluded.jar", "included_and_excluded"),
+                        TestArtifacts.createJarArtifact(
+                                projectDir, "my-project-excluded_classifier.jar", "excluded_classifier")));
+
+        File workingDirectory = new File(projectDir, "my_working_dir");
+        workingDirectory.mkdir();
+
+        File archiveDirectory = new File(projectDir, "my_archive_dir");
+        archiveDirectory.mkdir();
+        TestArtifacts.createDummyZipFile(new File(archiveDirectory, "archive1.jar"));
+        File previouslySignedArchive =
+                TestArtifacts.createDummySignedJarFile(new File(archiveDirectory, "previously_signed_archive.jar"));
+        assertTrue(
+                "previously_signed_archive.jar should be detected as a signed file before executing the Mojo",
+                JarSignerUtil.isArchiveSigned(previouslySignedArchive));
+        TestArtifacts.createDummyZipFile(new File(archiveDirectory, "archive_to_exclude.jar"));
+        TestArtifacts.createDummyZipFile(new File(archiveDirectory, "not_this.par"));
+
+        configuration.put("alias", "myalias");
+
+        // Setting "archive" parameter disables effect of many others, so it is tested separately in other test case
+
+        configuration.put("archiveDirectory", archiveDirectory.getPath());
+        configuration.put("arguments", "jarsigner-arg1,jarsigner-arg2");
+        configuration.put("certchain", "mycertchain");
+        configuration.put("excludeClassifiers", "excluded_classifier,included_and_excluded");
+        configuration.put("includeClassifiers", "sources,javadoc,included_and_excluded");
+        configuration.put("includes", "*.jar");
+        configuration.put("excludes", "*_to_exclude.jar");
+        configuration.put("keypass", "mykeypass");
+        configuration.put("keystore", "mykeystore");
+        configuration.put("maxMemory", "mymaxmemory");
+        configuration.put("processAttachedArtifacts", "true"); // Is default true, but set anyway.
+        configuration.put("processMainArtifact", "true"); // Is default true, but set anyway.
+        configuration.put("protectedAuthenticationPath", "true");
+        configuration.put("providerArg", "myproviderarg");
+        configuration.put("providerClass", "myproviderclass");
+        configuration.put("providerName", "myprovidername");
+        configuration.put("removeExistingSignatures", "true");
+        configuration.put("sigfile", "mysigfile");
+
+        configuration.put("skip", "false"); // Is default false, but set anyway
+        configuration.put("storepass", "mystorepass");
+        configuration.put("storetype", "mystoretype");
+        configuration.put("tsa", "mytsa");
+        configuration.put("tsacert", "mytsacert");
+        configuration.put("verbose", "true");
+        configuration.put("workingDirectory", workingDirectory.getPath());
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        ArgumentCaptor<JarSignerSignRequest> requestArgument = ArgumentCaptor.forClass(JarSignerSignRequest.class);
+        verify(jarSigner, times(5)).execute(requestArgument.capture());
+        List<JarSignerSignRequest> requests = requestArgument.getAllValues();
+
+        assertThat(requests, everyItem(RequestMatchers.hasAlias("myalias")));
+
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("archive1.jar")));
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("previously_signed_archive.jar")));
+        assertThat(requests, hasItem(not(RequestMatchers.hasFileName("archive_to_exclude.jar"))));
+        assertThat(requests, hasItem(not(RequestMatchers.hasFileName("not_this.par"))));
+
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("my-project.jar")));
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("my-project-sources.jar")));
+        assertThat(requests, hasItem(RequestMatchers.hasFileName("my-project-javadoc.jar")));
+        assertThat(requests, hasItem(not(RequestMatchers.hasFileName("my-project-included_and_excluded.jar"))));
+        assertThat(requests, hasItem(not(RequestMatchers.hasFileName("my-project-excluded_classifier.jar"))));
+
+        assertThat(
+                requests, everyItem(RequestMatchers.hasArguments(new String[] {"jarsigner-arg1", "jarsigner-arg2"})));
+        assertThat(requests, everyItem(RequestMatchers.hasCertchain("mycertchain")));
+        assertThat(requests, everyItem(RequestMatchers.hasKeypass("mykeypass")));
+        assertThat(requests, everyItem(RequestMatchers.hasKeystore("mykeystore")));
+        assertThat(requests, everyItem(RequestMatchers.hasMaxMemory("mymaxmemory")));
+        assertThat(requests, everyItem(RequestMatchers.hasProtectedAuthenticationPath(true)));
+        assertThat(requests, everyItem(RequestMatchers.hasProviderArg("myproviderarg")));
+        assertThat(requests, everyItem(RequestMatchers.hasProviderClass("myproviderclass")));
+        assertThat(requests, everyItem(RequestMatchers.hasProviderName("myprovidername")));
+        assertFalse(JarSignerUtil.isArchiveSigned(previouslySignedArchive)); // Make sure previous signing is gone
+        assertThat(requests, everyItem(RequestMatchers.hasSigfile("mysigfile")));
+        assertThat(requests, everyItem(RequestMatchers.hasStorepass("mystorepass")));
+        assertThat(requests, everyItem(RequestMatchers.hasStoretype("mystoretype")));
+        assertThat(requests, everyItem(RequestMatchers.hasTsa("mytsa")));
+        assertThat(requests, everyItem(RequestMatchers.hasTsacert("mytsacert")));
+        assertThat(requests, everyItem(RequestMatchers.hasVerbose(true)));
+    }
+
+    /** Make sure that if a custom ToolchainManager is set on the Mojo, it is used by jarSigner */
+    @Test
+    public void testToolchainManager() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        Toolchain toolchain = mock(Toolchain.class);
+        ToolchainManager toolchainManager = mock(ToolchainManager.class);
+        when(toolchainManager.getToolchainFromBuildContext(any(), any())).thenReturn(toolchain);
+        mojoTestCreator.setToolchainManager(toolchainManager);
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner).setToolchain(toolchain);
+    }
+
+    /** Make sure the Mojo correctly invokes the SecDispatcher for decryption of passwords */
+    @Test
+    public void testSecurityDispatcher() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        configuration.put("keypass", "mykeypass_encrypted");
+        configuration.put("storepass", "mystorepass_encrypted");
+
+        mojoTestCreator.setSecDispatcher(str -> str.replace("_encrypted", "")); // "Decrypts" a password
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner).execute(MockitoHamcrest.argThat(RequestMatchers.hasKeypass("mykeypass")));
+        verify(jarSigner).execute(MockitoHamcrest.argThat(RequestMatchers.hasStorepass("mystorepass")));
+    }
+
+    /** Make sure that a customer file encoding to jarsigner can be set and that it does not get duplicated */
+    @Test
+    public void testSetCustomFileEncoding() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("arguments", "-J-Dfile.encoding=ISO-8859-1,argument2");
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner)
+                .execute(MockitoHamcrest.argThat(
+                        RequestMatchers.hasArguments(new String[] {"-J-Dfile.encoding=ISO-8859-1", "argument2"})));
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.jarsigner.JarSigner;
+import org.apache.maven.shared.jarsigner.JarSignerVerifyRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.hamcrest.MockitoHamcrest;
+
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
+import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JarsignerVerifyMojoTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private MavenProject project = mock(MavenProject.class);
+    private JarSigner jarSigner = mock(JarSigner.class);
+    private File dummyMavenProjectDir;
+    private Map<String, String> configuration = new LinkedHashMap<>();
+    private Log log;
+    private MojoTestCreator<JarsignerVerifyMojo> mojoTestCreator;
+
+    @Before
+    public void setUp() throws Exception {
+        dummyMavenProjectDir = folder.newFolder("dummy-project");
+        mojoTestCreator = new MojoTestCreator<JarsignerVerifyMojo>(
+                JarsignerVerifyMojo.class, project, dummyMavenProjectDir, jarSigner);
+        log = mock(Log.class);
+        mojoTestCreator.setLog(log);
+    }
+
+    /** Standard Java project with nothing special configured */
+    @Test
+    public void testStandardJavaProject() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        ArgumentCaptor<JarSignerVerifyRequest> requestArgument = ArgumentCaptor.forClass(JarSignerVerifyRequest.class);
+        verify(jarSigner).execute(requestArgument.capture());
+        JarSignerVerifyRequest request = requestArgument.getValue();
+
+        assertFalse(request.isVerbose());
+        assertNull(request.getKeystore());
+        assertNull(request.getStoretype());
+        assertNull(request.getStorepass());
+        assertNull(request.getAlias());
+        assertNull(request.getProviderName());
+        assertNull(request.getProviderClass());
+        assertNull(request.getProviderArg());
+        assertNull(request.getMaxMemory());
+        assertThat(request.getArguments()[0], startsWith("-J-Dfile.encoding="));
+        assertEquals(dummyMavenProjectDir, request.getWorkingDirectory());
+        assertEquals(mainArtifact.getFile(), request.getArchive());
+        assertFalse(request.isProtectedAuthenticationPath());
+
+        assertFalse(request.isCerts()); // Only verify specific parameter
+    }
+
+    /** Invocing jarsigner with the -certs parameter */
+    @Test
+    public void testCertsTrue() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("certs", "true");
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner).execute(argThat(request -> ((JarSignerVerifyRequest) request).isCerts()));
+    }
+
+    /** When the jarsigner signing verification check tells there is a problem with the signing of the file */
+    @Test
+    public void testVerifyFailure() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_ERROR);
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+
+        MojoExecutionException mojoException = assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+        assertThat(mojoException.getMessage(), containsString(String.valueOf(RESULT_ERROR.getExitCode())));
+        assertThat(
+                mojoException.getMessage(),
+                containsString(RESULT_ERROR.getCommandline().toString()));
+    }
+
+    /** When setting errorWhenNotSigned, for file that has existing signing (should not fail) */
+    @Test
+    public void testErrorWhenNotSignedOnExistingSigning() throws Exception {
+        File signedJar = TestArtifacts.createDummySignedJarFile(new File(dummyMavenProjectDir, "my-project.jar"));
+        Artifact mainArtifact = TestArtifacts.createArtifact(signedJar);
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("errorWhenNotSigned", "true");
+
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        verify(jarSigner).execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("my-project.jar")));
+    }
+
+    /** When setting errorWhenNotSigned, for file that does not have existing signing (should fail) */
+    @Test
+    public void testErrorWhenNotSignedOnNonExistingSigning() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("errorWhenNotSigned", "true");
+
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+
+        MojoExecutionException mojoException = assertThrows(MojoExecutionException.class, () -> {
+            mojo.execute();
+        });
+        assertThat(
+                mojoException.getMessage(),
+                containsString(mainArtifact.getFile().getPath()));
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.jarsigner.JarsignerSignMojo.WaitStrategy;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.jarsigner.JarSigner;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
+
+/**
+ * Creates and configures a Mojo instance to be used in testing.
+ *
+ * @param <T> The type of Mojo
+ */
+public class MojoTestCreator<T extends AbstractJarsignerMojo> {
+
+    private final Logger logger = LoggerFactory.getLogger(MojoTestCreator.class);
+
+    private final Class<T> clazz;
+    private final MavenProject project;
+    private final File projectDir;
+    private final JarSigner jarSigner;
+    private ToolchainManager toolchainManager;
+    private SecDispatcher securityDispatcher;
+    private WaitStrategy waitStrategy;
+    private Log log;
+    private List<Field> fields;
+
+    public MojoTestCreator(Class<T> clazz, MavenProject project, File projectDir, JarSigner jarSigner)
+            throws Exception {
+        this.clazz = clazz;
+        this.project = project;
+        this.projectDir = projectDir;
+        this.jarSigner = jarSigner;
+
+        securityDispatcher = str -> str; // Simple SecDispatcher that only returns parameter
+        fields = getAllFields(clazz);
+    }
+
+    public void setToolchainManager(ToolchainManager toolchainManager) {
+        this.toolchainManager = toolchainManager;
+    }
+
+    public void setSecDispatcher(SecDispatcher securityDispatcher) {
+        this.securityDispatcher = securityDispatcher;
+    }
+
+    public void setWaitStrategy(WaitStrategy waitStrategy) {
+        this.waitStrategy = waitStrategy;
+    }
+
+    public void setLog(Log log) {
+        this.log = log;
+    }
+
+    /**
+     * Creates and configures the Mojo instance.
+     * @param configuration user supplied configuration.
+     */
+    public T configure(Map<String, String> configuration) throws Exception {
+        T mojo = clazz.getDeclaredConstructor().newInstance();
+        setDefaultValues(mojo);
+
+        setAttribute(mojo, "project", project);
+        setAttribute(mojo, "jarSigner", jarSigner);
+        setAttribute(mojo, "securityDispatcher", securityDispatcher);
+        if (toolchainManager != null) {
+            setAttribute(mojo, "toolchainManager", toolchainManager);
+        }
+        if (waitStrategy != null) {
+            ((JarsignerSignMojo) mojo).setWaitStrategy(waitStrategy);
+        }
+        if (log != null) {
+            mojo.setLog(log);
+        }
+
+        for (Map.Entry<String, String> entry : configuration.entrySet()) {
+            Field field = getField(mojo, entry.getKey());
+            setFieldByStringValue(mojo, field, entry.getValue());
+        }
+
+        return mojo;
+    }
+
+    private void setFieldByStringValue(Object instance, Field field, String stringValue) throws Exception {
+        field.setAccessible(true);
+        Class<?> fieldType = field.getType();
+        if (fieldType.equals(String.class)) {
+            field.set(instance, stringValue);
+        } else if (fieldType.equals(int.class)) {
+            field.setInt(instance, Integer.parseInt(stringValue));
+        } else if (fieldType.equals(boolean.class)) {
+            field.setBoolean(instance, Boolean.parseBoolean(stringValue));
+        } else if (fieldType.equals(File.class)) {
+            field.set(instance, new File(stringValue));
+        } else if (fieldType.equals(String[].class)) {
+            String[] values = stringValue.split(",");
+            field.set(instance, values);
+        } else {
+            if (!stringValue.startsWith("${")) {
+                logger.warn(
+                        "Not implemented support to set of field of type {} to value {}",
+                        fieldType.getSimpleName(),
+                        stringValue);
+            }
+        }
+    }
+
+    private Field getField(Object instance, String fieldName) {
+        return fields.stream()
+                .filter(f -> f.getName().equals(fieldName))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Could not find field " + fieldName + " in class "
+                        + instance.getClass().getName()));
+    }
+
+    private void setAttribute(Object instance, String fieldName, Object value) throws Exception {
+        Field field = getField(instance, fieldName);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
+
+    private void setDefaultValues(Mojo mojo) throws Exception {
+        Map<String, String> defaultConfiguration = PluginXmlParser.getMojoDefaultConfiguration(mojo.getClass());
+        for (String parameterName : defaultConfiguration.keySet()) {
+            String defaultValue = defaultConfiguration.get(parameterName);
+            defaultValue = substituteParameterValueVariables(defaultValue);
+            Field field = getField(mojo, parameterName);
+            setFieldByStringValue(mojo, field, defaultValue.toString());
+        }
+    }
+
+    private String substituteParameterValueVariables(String parameterValue) {
+        parameterValue = parameterValue.replaceAll(
+                Pattern.quote("${project.basedir}"), Matcher.quoteReplacement(projectDir.getPath()));
+        return parameterValue;
+    }
+
+    static List<Field> getAllFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        Class<?> currentClazz = clazz;
+        while (currentClazz != null) {
+            fields.addAll(Arrays.asList(currentClazz.getDeclaredFields()));
+            currentClazz = currentClazz.getSuperclass();
+        }
+        return fields;
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/PluginXmlParser.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/PluginXmlParser.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.maven.plugin.Mojo;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parser of the generated META-INF/maven/plugin.xml for this project. The plugin.xml contains all mojos their
+ * configuration parameters along with default values.
+ */
+public class PluginXmlParser {
+    private static final String MOJO_IMPLEMENTATION_TAG = "implementation";
+    private static final String MOJO_TAG = "mojo";
+    private static final String CONF_DEFAULT_VALUE = "default-value";
+    private static final String PLUGIN_XML_PATH = "META-INF/maven/plugin.xml";
+
+    public static Map<String, String> getMojoDefaultConfiguration(Class<? extends Mojo> mojoClass) throws Exception {
+        Map<String, String> defaultConfiguration = new LinkedHashMap<>();
+        InputStream inputStream = PluginXmlParser.class.getClassLoader().getResourceAsStream(PLUGIN_XML_PATH);
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(inputStream);
+        doc.getDocumentElement().normalize();
+
+        Element mojoElement = findMojoByClass(doc, mojoClass.getName());
+        if (mojoElement == null) {
+            throw new RuntimeException("Mojo not found for class: " + mojoClass.getName());
+        }
+
+        Element configurationElement =
+                (Element) mojoElement.getElementsByTagName("configuration").item(0);
+        NodeList configurationList = configurationElement.getChildNodes();
+        for (int i = 0; i < configurationList.getLength(); i++) {
+            Node child = configurationList.item(i);
+            if (child.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            configurationElement = (Element) child;
+            String configurationParameterName = configurationElement.getTagName();
+
+            if (configurationElement.hasAttribute(CONF_DEFAULT_VALUE)) {
+                String defaultValue = configurationElement.getAttribute(CONF_DEFAULT_VALUE);
+                defaultConfiguration.put(configurationParameterName, defaultValue);
+            }
+        }
+        return defaultConfiguration;
+    }
+
+    /** Searches in every mojo tag for an implementation tag matching the class name */
+    private static Element findMojoByClass(Document doc, String className) {
+        NodeList mojoList = doc.getElementsByTagName(MOJO_TAG);
+        for (int i = 0; i < mojoList.getLength(); i++) {
+            Element mojoElement = (Element) mojoList.item(i);
+            String mojoClass = getTextContent(mojoElement, MOJO_IMPLEMENTATION_TAG);
+            if (mojoClass.equals(className)) {
+                return mojoElement;
+            }
+        }
+        return null;
+    }
+
+    private static String getTextContent(Element parentElement, String tagName) {
+        NodeList nodeList = parentElement.getElementsByTagName(tagName);
+        if (nodeList.getLength() > 0) {
+            return nodeList.item(0).getTextContent();
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/RequestMatchers.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/RequestMatchers.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.apache.maven.shared.jarsigner.AbstractJarSignerRequest;
+import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Hamcrest matcher(s) to match properties on a JarSignerRequest request instances
+ */
+class RequestMatchers {
+
+    /** Matcher for parameters common for JarSignerRequest instances */
+    private static class AbstractJarSignerRequestMatcher<T extends AbstractJarSignerRequest>
+            extends TypeSafeMatcher<T> {
+        private final String predicateDescription;
+        private final Object value;
+        private final Predicate<AbstractJarSignerRequest> predicate;
+
+        private AbstractJarSignerRequestMatcher(
+                String predicateDescription, Object value, Predicate<AbstractJarSignerRequest> predicate) {
+            this.predicateDescription = predicateDescription;
+            this.value = value;
+            this.predicate = predicate;
+        }
+
+        @Override
+        protected boolean matchesSafely(AbstractJarSignerRequest request) {
+            return predicate.test(request);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description
+                    .appendText("request that ")
+                    .appendText(predicateDescription)
+                    .appendValue(value);
+        }
+    }
+
+    /** Matcher for parameters specific to JarSignerSignRequest instances */
+    private static class JarSignerSignRequestMatcher extends TypeSafeMatcher<JarSignerSignRequest> {
+        private final String predicateDescription;
+        private final Object value;
+        private final Predicate<JarSignerSignRequest> predicate;
+
+        private JarSignerSignRequestMatcher(
+                String predicateDescription, Object value, Predicate<JarSignerSignRequest> predicate) {
+            this.predicateDescription = predicateDescription;
+            this.value = value;
+            this.predicate = predicate;
+        }
+
+        @Override
+        protected boolean matchesSafely(JarSignerSignRequest request) {
+            return predicate.test(request);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description
+                    .appendText("request that ")
+                    .appendText(predicateDescription)
+                    .appendValue(value);
+        }
+    }
+
+    /** Create a matcher that matches when the request is using a specific file name for the archive */
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasFileName(String expectedFileName) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has archive file name ",
+                expectedFileName,
+                request -> request.getArchive().getPath().endsWith(expectedFileName));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasAlias(String alias) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has alias ", alias, request -> request.getAlias().equals(alias));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasArguments(String[] arguments) {
+        return new AbstractJarSignerRequestMatcher<T>("has arguments ", arguments, request -> {
+            List<String> haystack = Arrays.asList(request.getArguments());
+            for (String argumentNeedle : arguments) {
+                if (!haystack.contains(argumentNeedle)) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasKeystore(String keystore) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has keystore ", keystore, request -> request.getKeystore().equals(keystore));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasMaxMemory(String maxMemory) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has maxMemory ", maxMemory, request -> request.getMaxMemory().equals(maxMemory));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasProtectedAuthenticationPath(
+            boolean protectedAuthenticationPath) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has protectedAuthenticationPath ",
+                protectedAuthenticationPath,
+                request -> request.isProtectedAuthenticationPath() == protectedAuthenticationPath);
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasProviderArg(String providerArg) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has providerArg ", providerArg, request -> request.getProviderArg()
+                        .equals(providerArg));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasProviderClass(String providerClass) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has providerClass ", providerClass, request -> request.getProviderClass()
+                        .equals(providerClass));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasProviderName(String providerName) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has providerName ", providerName, request -> request.getProviderName()
+                        .equals(providerName));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasStorepass(String storepass) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has storepass ", storepass, request -> request.getStorepass().equals(storepass));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasStoretype(String storetype) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has storetype ", storetype, request -> request.getStoretype().equals(storetype));
+    }
+
+    static <T extends AbstractJarSignerRequest> TypeSafeMatcher<T> hasVerbose(boolean verbose) {
+        return new AbstractJarSignerRequestMatcher<T>(
+                "has verbose ", verbose, request -> request.isVerbose() == verbose);
+    }
+
+    /* ************************************ JarSignerSignRequest specific matchers ************************************/
+
+    static TypeSafeMatcher<JarSignerSignRequest> hasKeypass(String keypass) {
+        return new JarSignerSignRequestMatcher(
+                "has keypass ", keypass, request -> request.getKeypass().equals(keypass));
+    }
+
+    static TypeSafeMatcher<JarSignerSignRequest> hasSigfile(String sigfile) {
+        return new JarSignerSignRequestMatcher(
+                "has sigfile ", sigfile, request -> request.getSigfile().equals(sigfile));
+    }
+
+    static TypeSafeMatcher<JarSignerSignRequest> hasTsa(String tsa) {
+        return new JarSignerSignRequestMatcher(
+                "has tsa ", tsa, request -> request.getTsaLocation().equals(tsa));
+    }
+
+    static TypeSafeMatcher<JarSignerSignRequest> hasTsacert(String tsacert) {
+        return new JarSignerSignRequestMatcher(
+                "has tsacert ", tsacert, request -> request.getTsaAlias().equals(tsacert));
+    }
+
+    static TypeSafeMatcher<JarSignerSignRequest> hasCertchain(String certchain) {
+        return new JarSignerSignRequestMatcher("has certchain ", certchain, request -> request.getCertchain()
+                .getPath()
+                .equals(certchain));
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TestArtifacts.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TestArtifacts.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+
+/**
+ * Test utility class to create Artifact objects, jar file or other files that Maven attaches to a project
+ */
+class TestArtifacts {
+    static final String TEST_GROUPID = "org.test-group";
+    static final String TEST_ARTIFACTID = "test-artifact";
+    static final String TEST_VERSION = "9.10.2";
+    static final String TEST_TYPE = "jar";
+    static final String TEST_CLASSIFIER = "";
+
+    static Artifact createArtifact(File file) throws IOException {
+        return createArtifact(file, TEST_TYPE, TEST_CLASSIFIER);
+    }
+
+    static Artifact createArtifact(File file, String type, String classifier) throws IOException {
+        Artifact artifact = new DefaultArtifact(
+                TEST_GROUPID, TEST_ARTIFACTID, TEST_VERSION, Artifact.SCOPE_COMPILE, type, classifier, null);
+        artifact.setFile(file);
+        return artifact;
+    }
+
+    static Artifact createJarArtifact(File directory, String filename) throws IOException {
+        return createJarArtifact(directory, filename, TEST_CLASSIFIER);
+    }
+
+    public static Artifact createJarArtifact(File directory, String filename, String classifier) throws IOException {
+        return createJarArtifact(directory, filename, classifier, TEST_TYPE);
+    }
+
+    public static Artifact createJarArtifact(File directory, String filename, String classifier, String type)
+            throws IOException {
+        File file = new File(directory, filename);
+        createDummyZipFile(file);
+        return createArtifact(file, type, classifier);
+    }
+
+    static Artifact createPomArtifact(File directory, String filename) throws IOException {
+        File file = new File(directory, filename);
+        createDummyXMLFile(file);
+        return createArtifact(file, TEST_TYPE, "");
+    }
+
+    /** Create a dummy JAR/ZIP file, enough to pass ZipInputStream.getNextEntry() */
+    static File createDummyZipFile(File zipFile) throws IOException {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            ZipEntry entry = new ZipEntry("dummy-entry.txt");
+            zipOutputStream.putNextEntry(entry);
+        }
+        return zipFile;
+    }
+
+    /** Create a dummy signed JAR, enough to pass JarSignerUtil.isArchiveSigned() */
+    static File createDummySignedJarFile(File jarFile) throws IOException {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(jarFile))) {
+            ZipEntry entry = new ZipEntry("dummy-entry.txt");
+            zipOutputStream.putNextEntry(entry);
+            zipOutputStream.putNextEntry(new ZipEntry("META-INF/dummy.RSA"));
+        }
+
+        return jarFile;
+    }
+
+    /** Create a dummy XML file, for example to simulate a pom.xml file */
+    static File createDummyXMLFile(File xmlFile) throws IOException {
+        Files.write(xmlFile.toPath(), "<project/>".getBytes());
+        return xmlFile;
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TestJavaToolResults.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TestJavaToolResults.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jarsigner;
+
+import org.apache.maven.shared.utils.cli.Commandline;
+import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
+import org.apache.maven.shared.utils.cli.shell.Shell;
+
+/**
+ * Results from an invocation to {@link org.apache.maven.shared.utils.cli.javatool.JavaTool} to be used in tests.
+ */
+class TestJavaToolResults {
+    static final JavaToolResult RESULT_OK = createOk();
+    static final JavaToolResult RESULT_ERROR = createError();
+
+    private static JavaToolResult createOk() {
+        JavaToolResult result = new JavaToolResult();
+        result.setExitCode(0);
+        result.setExecutionException(null);
+        result.setCommandline(getSimpleCommandline());
+        return result;
+    }
+
+    private static JavaToolResult createError() {
+        JavaToolResult result = new JavaToolResult();
+        result.setExitCode(1);
+        result.setExecutionException(null);
+        result.setCommandline(getSimpleCommandline());
+        return result;
+    }
+
+    private static Commandline getSimpleCommandline() {
+        Shell shell = new Shell();
+        Commandline commandline = new Commandline(shell);
+        commandline.setExecutable("jarsigner");
+        commandline.addArguments("my-project.jar", "myalias");
+        return commandline;
+    }
+}


### PR DESCRIPTION
This pull request implements https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-41 that introduces a retry feature for when jar signing fails (typically for network issues). It also implements a delay feature between retries. 

In this pull request I have:
1. Used the pull request https://github.com/apache/maven-jarsigner-plugin/pull/1 by @lasselindqvist as base along with the branch https://github.com/apache/maven-jarsigner-plugin/tree/MJARSIGNER-41 by @slachiewicz.
2. Also integrated the suggested change by https://github.com/apache/maven-jarsigner-plugin/pull/3 by @bdt-stru.
3. Fixed https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-68 (edit: made dedicated pull request https://github.com/apache/maven-jarsigner-plugin/pull/15 for this)
4. Written a huge number of tests.

I thought a lot about whether both signing and verification should have the retry feature. In the end I felt the code would be better if only the signing had the retry feature. I’m unsure if any verification may fail due to external circumstances. Perhaps if external Certificate Revocation Lists (CRLs) are used? But I’m unsure if jarsigner performs such a check to an external network resource?

I opted to use `@since 3.1.0` declaration(s) for the added parameters. Feel free to change/suggest other values for this! 

I spent some time thinking about if a linear or exponential backoff algorithm for sleeping should be used. In the end I made a simple exponential backoff implementation with only one configurable parameter (maxRetryDelay). It would be possible to also add configuration for initalDelay (hard coded to 1 second) and multiplier (hard coded to 2), but I choose not to do this to keep things simple.

I considered implementing support for multiple tsa lists. It was suggested by Thorsten Meinl as a patch to https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-59 and also by @jcompagner in https://github.com/apache/maven-jarsigner-plugin/pull/1#issuecomment-1412344998. I think this could be a good idea, but I did not want to “pollute” my pull request. If it was to be implemented I think the way forward is to change type of JarsignerSignMojo.tsa from a String to String[] and let Maven default array handling handle this (it will then handle both using comma separation, or nested XML tags). But my guess is that an adding of tsa list would “force” to also use a list for -tsacert and also the non-existent parameter -tsapolicyid? Because tsa, tsacert and tsapolicyid all belong together as a triplet.

I implemented varargs for the `getMessage()` methods to make them cleaner.

With the combination of what bdt-stru and lasselindqvist added I ended up adding one log and one obscure exception (that will not happen often) that does not have internationalization (see `JarsignerSignMojo.defaultWaitStrategy()`). My own feeling is that if the Mojo configuration site documentation does not have internationalization, is it that important that some corner case log messages also does not have it?

I spend a lot of time writing test cases. My motivation for this is that I like tests and that I plan to continue working to implement https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-72. I suspect I will need some refactoring and a safety net when I begin with that.

While writing test case I saw that maven-jarsigner-plugin was missing support for the `-signedjar` parameter. But I did not have a direct need to have this feature, so I did not implement it. I cannot find any ticket for this on https://issues.apache.org/jira/projects/MJARSIGNER/issues so I guess there is no high need for it.

I tried using maven Maven Plugin Testing Harness (https://maven.apache.org/plugin-testing/maven-plugin-testing-harness/). I spent many hours on it. I felt that the documentation/implementation was not mature enough to use. I did not find any good way of injecting custom instances of JarSigner/MavenSession/MavenProject. It is possible to make Maven Plugin Testing Harness instantiate a class (that is runing the default constructor). But that was not enough for me: I needed to tailor the instances. The way to make it instantiate custom classes was too cumbersome in my opinion (that I had to go via a pom.xml file on disk). It was possible to create via Java methods only, but those methods were not documented. All in all, I decided to create my own mini-test hardness framework (see MojoTestCreator.java and PluginXmlParser.java).

Since slachiewicz, in the integration branch https://github.com/apache/maven-jarsigner-plugin/tree/MJARSIGNER-41, tried to use jacoco for code coverage I completed the configuration so that Jacoco will output HTML reports in target/site/jacoco/index.html. Unfortunately, I don’t have access or don’t fully understand how the CI (Jenkins?) server https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-jarsigner-plugin/ works to know what good values are for a code coverage report to be shown on a job build page.

Just as Elliotte Rusty has noted in https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-68 the integration test /src/it/verify-fail/pom.xml fails when I executed it (mvn clean install -P+run-its). I have made a fix for this and documented how I did to generate the tampered.jar in src/it/verify-fail/pom.xml.


