### PR TITLE
[MJARSIGNER-62] Enhanced documentation for usage of arguments

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -146,7 +146,21 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
     private String[] excludes = {};
 
     /**
-     * List of additional arguments to append to the jarsigner command line.
+     * List of additional arguments to append to the jarsigner command line. Each argument should be specified as a
+     * separate element. For example, to specify the name of the signed jar, two elements are needed:
+     * <ul>
+     *     <li>Alternative using the command line: {@code -Djarsigner.arguments="-signedjar,my-project_signed.jar"}</li>
+     *     <li>Alternative using the Maven POM configuration:</li>
+     * </ul>
+     * <pre>
+     * {@code
+     * <configuration>
+     *     <arguments>
+     *         <argument>-signedjar</argument>
+     *         <argument>my-project_signed.jar</argument>
+     *     </arguments>
+     * </configuration>
+     * }</pre>
      */
     @Parameter(property = "jarsigner.arguments")
     private String[] arguments;


### PR DESCRIPTION
The author of https://issues.apache.org/jira/projects/MJARSIGNER/issues/MJARSIGNER-62 would like to use a 2-element additional argument to the jarsigner command line. The author believes that the problem they are having is that maven-jarsigner-plugin (on top of the https://github.com/apache/maven-jarsigner project) is quoting the arguments, and that is causing the problem.

I believe that the author is not correct: it is how the arguments were used by the author that is the problem. But I still think that the author has a good point. I my opinion the `arguments` parameter is not properly documented. You must be experienced with Maven to understand how to use it. I have used Maven for many years, and I still have problems with this. This pull request improves the documentation, so it is understandable for even a novice Maven user. When this pull request is accepted, I think that MJARSIGNER-62 can be closed.

As an example, the `-certchain` is used in the ticket description. For this specific parameter there already exists a dedicated parameter. If/when https://github.com/apache/maven-jarsigner-plugin/pull/14 is accepted this will also have a correct documentation on https://maven.apache.org/plugins/maven-jarsigner-plugin/sign-mojo.html

As an example, in this pull request, I have selected a parameter that maven-jarsigner-plugin does not have support for: `-signedjar file`. This is a good parameter as an example because I don’t think maven-jarsigner-plugin will implement support for this (since maven-jarsigner-plugin is used to sign many jarfiles, it does not make sense to overwrite every jar into a single output jarfile).


Example of rendered output:
![image](https://github.com/apache/maven-jarsigner-plugin/assets/8510257/ef70534f-1219-483e-8265-aee4e4a74d5d)
