### PR TITLE
[MJARSIGNER-76] Print names of processed files

### DIFF
--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -67,6 +67,7 @@ public class JarsignerSignMojoParallelTest {
     @Before
     public void setUp() throws Exception {
         projectDir = folder.newFolder("dummy-project");
+        when(project.getBasedir()).thenReturn(projectDir);
         configuration.put("processMainArtifact", "false");
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
@@ -72,6 +72,7 @@ public class JarsignerSignMojoRetryTest {
         originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
         projectDir = folder.newFolder("dummy-project");
+        when(project.getBasedir()).thenReturn(projectDir);
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
         log = mock(Log.class);

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -62,6 +62,7 @@ public class JarsignerVerifyMojoTest {
     @Before
     public void setUp() throws Exception {
         dummyMavenProjectDir = folder.newFolder("dummy-project");
+        when(project.getBasedir()).thenReturn(dummyMavenProjectDir);
         mojoTestCreator = new MojoTestCreator<JarsignerVerifyMojo>(
                 JarsignerVerifyMojo.class, project, dummyMavenProjectDir, jarSigner);
         log = mock(Log.class);


### PR DESCRIPTION
Note that I am also the author of the Jira ticket. So no worries if you don't think this is useful for enough users, or if you want to wait until other users request this change too.

Note completely sure why the plugin wasn't printing the file paths before.
- It is probably not that verbose, assuming users normally only use Jarsigner on a few files.
- The file paths are probably also not a secret, so printing them does not leak any information.