### PR TITLE
Spell error fix tsaDigestAlt -> tsaDigestAlg

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -301,7 +301,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         request.setTsaLocation(tsaServer.getTsaUrl());
         request.setTsaAlias(tsaServer.getTsaAlias());
         request.setTsapolicyid(tsaServer.getTsaPolicyId());
-        request.setTsadigestalg(tsaServer.getTsaDigestAlt());
+        request.setTsadigestalg(tsaServer.getTsaDigestAlg());
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/TsaSelector.java
@@ -112,13 +112,13 @@ class TsaSelector {
         private final String tsaUrl;
         private final String tsaAlias;
         private final String tsaPolicyId;
-        private final String tsaDigestAlt;
+        private final String tsaDigestAlg;
 
-        private TsaServer(String tsaUrl, String tsaAlias, String tsaPolicyId, String tsaDigestAlt) {
+        private TsaServer(String tsaUrl, String tsaAlias, String tsaPolicyId, String tsaDigestAlg) {
             this.tsaUrl = tsaUrl;
             this.tsaAlias = tsaAlias;
             this.tsaPolicyId = tsaPolicyId;
-            this.tsaDigestAlt = tsaDigestAlt;
+            this.tsaDigestAlg = tsaDigestAlg;
         }
 
         String getTsaUrl() {
@@ -133,8 +133,8 @@ class TsaSelector {
             return tsaPolicyId;
         }
 
-        String getTsaDigestAlt() {
-            return tsaDigestAlt;
+        String getTsaDigestAlg() {
+            return tsaDigestAlg;
         }
     }
 }

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -43,14 +43,14 @@ public class TsaSelectorTest {
         assertNull(tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertNull(tsaServer.getTsaDigestAlt());
+        assertNull(tsaServer.getTsaDigestAlg());
 
         // Make sure "next" server also contains null values
         tsaServer = tsaSelector.getServer();
         assertNull(tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertNull(tsaServer.getTsaDigestAlt());
+        assertNull(tsaServer.getTsaDigestAlg());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class TsaSelectorTest {
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertNull(tsaServer.getTsaDigestAlt());
+        assertNull(tsaServer.getTsaDigestAlg());
 
         tsaSelector.registerFailure();
 
@@ -70,14 +70,14 @@ public class TsaSelectorTest {
         assertEquals("http://url2.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertNull(tsaServer.getTsaDigestAlt());
+        assertNull(tsaServer.getTsaDigestAlg());
 
         // Should get same server again
         tsaServer = tsaSelector.getServer();
         assertEquals("http://url2.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertNull(tsaServer.getTsaDigestAlt());
+        assertNull(tsaServer.getTsaDigestAlg());
     }
 
     @Test(timeout = 30000)
@@ -135,7 +135,7 @@ public class TsaSelectorTest {
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertEquals("SHA-512", tsaServer.getTsaDigestAlt());
+        assertEquals("SHA-512", tsaServer.getTsaDigestAlg());
 
         // Make sure that the next URL has the same digest algorithm
         tsaSelector.registerFailure();
@@ -143,7 +143,7 @@ public class TsaSelectorTest {
         assertEquals("http://url2.com", tsaServer.getTsaUrl());
         assertNull(tsaServer.getTsaAlias());
         assertNull(tsaServer.getTsaPolicyId());
-        assertEquals("SHA-512", tsaServer.getTsaDigestAlt());
+        assertEquals("SHA-512", tsaServer.getTsaDigestAlg());
     }
 
     @Test
@@ -172,6 +172,6 @@ public class TsaSelectorTest {
         assertEquals("http://url1.com", tsaServer.getTsaUrl());
         assertEquals("alias1", tsaServer.getTsaAlias());
         assertEquals("1.1", tsaServer.getTsaPolicyId());
-        assertEquals("SHA-384", tsaServer.getTsaDigestAlt());
+        assertEquals("SHA-384", tsaServer.getTsaDigestAlg());
     }
 }


### PR DESCRIPTION
The spelling error "tsaDigestAlt" was introduced in the scope of MJARSIGNER-74 and https://github.com/apache/maven-jarsigner-plugin/pull/19

The spelling error only affected an internal package private class and was not visible in any external class/documentation.

