### PR TITLE
Add plexus-xml as explicit dependency required by plexus-sec-dispatcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,10 @@ under the License.
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
       <version>1.4</version>
-      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Since version 4 the xml tools of plexus-utils have been moved into plexus-xml, but plexus-utils only has an optional dependency on it. Since org.sonatype.plexus:plexus-sec-dispatcher is compiled against plexus-utils version 1.5 it expects the xml classes to be available and fails with an
`java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/XmlStreamReader`
in `org.sonatype.plexus.components.sec.dispatcher.SecUtil.read()`, when creating an instance of `SecurityConfigurationXpp3Reader`.

The full stack-trace is
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jarsigner-plugin:3.1.0:sign (sign-jars) on project foo:bar Error processing archives java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/XmlStreamReader: org.codehaus.plexus.util.xml.XmlStreamReader -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-jarsigner-plugin:3.1.0:sign (sign-jars) on project foo:bar: Error processing archives
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:333)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:316)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:174)
	at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:75)
	at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:162)
	at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:159)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:105)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:73)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:53)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:118)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:261)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:173)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:101)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:906)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:283)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:206)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:255)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:201)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:361)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:314)
Caused by: org.apache.maven.plugin.MojoExecutionException: Error processing archives
	at org.apache.maven.plugins.jarsigner.JarsignerSignMojo.processArchives(JarsignerSignMojo.java:330)
	at org.apache.maven.plugins.jarsigner.AbstractJarsignerMojo.execute(AbstractJarsignerMojo.java:284)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:126)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:328)
	... 25 more
Caused by: java.util.concurrent.ExecutionException: java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/XmlStreamReader
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.apache.maven.plugins.jarsigner.JarsignerSignMojo.processArchives(JarsignerSignMojo.java:321)
	... 28 more
Caused by: java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/XmlStreamReader
	at org.sonatype.plexus.components.sec.dispatcher.SecUtil.read(SecUtil.java:58)
	at org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher.getSec(DefaultSecDispatcher.java:206)
	at org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher.decrypt(DefaultSecDispatcher.java:90)
	at org.apache.maven.plugins.jarsigner.AbstractJarsignerMojo.decrypt(AbstractJarsignerMojo.java:561)
	at org.apache.maven.plugins.jarsigner.JarsignerSignMojo.createRequest(JarsignerSignMojo.java:295)
	at org.apache.maven.plugins.jarsigner.AbstractJarsignerMojo.processArchive(AbstractJarsignerMojo.java:472)
	at org.apache.maven.plugins.jarsigner.JarsignerSignMojo.lambda$processArchives$0(JarsignerSignMojo.java:315)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.util.xml.XmlStreamReader
	at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:42)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:225)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:210)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:205)
	... 11 more
```