### PR TITLE
Add smoke test for real plexus-sec-dispatcher DefaultSecDispatcher use

### DIFF
--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugins.jarsigner;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -42,6 +43,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.hamcrest.MockitoHamcrest;
+import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
+import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
@@ -461,5 +464,27 @@ public class JarsignerSignMojoTest {
         verify(log, times(1)).debug(contains("Forcibly ignoring attached artifacts"));
         verify(log, times(1)).debug(contains("Processing "));
         verify(log, times(1)).info(contains("1 archive(s) processed"));
+    }
+
+    @Test
+    public void testDefaultSecDispatcher() throws Exception {
+        String pw = "trivialPW";
+        String secrectText = "my-sigrid";
+        File securitySettings = folder.newFile("settings-security.xml");
+        Files.write(
+                securitySettings.toPath(),
+                Arrays.asList( //
+                        "<settingsSecurity>", //
+                        "<master>{tZdWvqoeiY0HNlIBiQwn5a+gsv7v0FVhjlrAqz6Q6Yc=}</master>", //
+                        "</settingsSecurity>"));
+
+        DefaultPlexusCipher cypher = new DefaultPlexusCipher();
+        DefaultSecDispatcher dispatcher = new DefaultSecDispatcher();
+        dispatcher.setConfigurationFile(securitySettings.toString());
+        new MojoTestCreator<>(DefaultSecDispatcher.class).setAttribute(dispatcher, "_cipher", cypher);
+
+        String encrypted = cypher.decorate(cypher.encrypt(secrectText, pw));
+        String decrypted = dispatcher.decrypt(encrypted);
+        assertEquals(secrectText, decrypted);
     }
 }

--- a/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/MojoTestCreator.java
@@ -54,7 +54,7 @@ public class MojoTestCreator<T extends AbstractJarsignerMojo> {
     private SecDispatcher securityDispatcher;
     private WaitStrategy waitStrategy;
     private Log log;
-    private List<Field> fields;
+    private final List<Field> fields;
 
     public MojoTestCreator(Class<T> clazz, MavenProject project, File projectDir, JarSigner jarSigner)
             throws Exception {
@@ -65,6 +65,14 @@ public class MojoTestCreator<T extends AbstractJarsignerMojo> {
 
         securityDispatcher = str -> str; // Simple SecDispatcher that only returns parameter
         fields = getAllFields(clazz);
+    }
+
+    public MojoTestCreator(Class<?> clazz) {
+        this.fields = getAllFields(clazz);
+        this.clazz = null;
+        this.project = null;
+        this.projectDir = null;
+        this.jarSigner = null;
     }
 
     public void setToolchainManager(ToolchainManager toolchainManager) {
@@ -149,7 +157,7 @@ public class MojoTestCreator<T extends AbstractJarsignerMojo> {
                         + instance.getClass().getName()));
     }
 
-    private void setAttribute(Object instance, String fieldName, Object value) throws Exception {
+    void setAttribute(Object instance, String fieldName, Object value) throws Exception {
         Field field = getField(instance, fieldName);
         field.setAccessible(true);
         field.set(instance, value);


### PR DESCRIPTION
This is an attempt for a reproducer of https://github.com/apache/maven-jarsigner-plugin/pull/40.

But currently this does not work because plexus-xml is pulled into the test-runtime, although it isn't on normal use. Actually this test should fail now, without #40, but it doesn't.

The changes in `MojoTestCreator` are just a quick-and-dirty solution to get the fields set. If you have any better suggestion, please don't hesitate to let me know.