### PR TITLE
Update parent and invoker plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugins</artifactId>
-    <version>43</version>
+    <version>45</version>
     <relativePath />
   </parent>
 
@@ -102,6 +102,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
+      <version>${version.maven-plugin-tools}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -204,6 +205,7 @@ under the License.
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-invoker-plugin</artifactId>
+              <version>3.9.1</version>
               <configuration>
                 <goals>
                   <goal>clean</goal>

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -46,11 +46,17 @@ import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERRO
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JarsignerSignMojoParallelTest {
     @Rule

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -39,13 +38,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.argThat;
@@ -143,7 +142,7 @@ public class JarsignerSignMojoRetryTest {
     }
 
     @Test
-    public void testInvalidMaxTries_zero() throws Exception {
+    public void testInvalidMaxTriesZero() throws Exception {
         when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_ERROR);
 
         configuration.put("maxTries", "0"); // Setting an "invalid" value
@@ -161,7 +160,7 @@ public class JarsignerSignMojoRetryTest {
     }
 
     @Test
-    public void testInvalidMaxTries_negative() throws Exception {
+    public void testInvalidMaxTriesNegative() throws Exception {
         // Make result ok, to make this test check more things (compared to testInvalidMaxTries_zero())
         when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
 
@@ -195,7 +194,7 @@ public class JarsignerSignMojoRetryTest {
     }
 
     @Test
-    public void testInvalidMaxRetryDelaySeconds_negative() throws Exception {
+    public void testInvalidMaxRetryDelaySecondsNegative() throws Exception {
         when(jarSigner.execute(any(JarSignerSignRequest.class)))
                 .thenReturn(RESULT_ERROR)
                 .thenReturn(RESULT_OK);
@@ -217,16 +216,16 @@ public class JarsignerSignMojoRetryTest {
     public void testDefaultWaitStrategy() throws Exception {
         JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
 
-        long NO_SLEEP_VALUE = 42_001;
+        final long noSleepValue = 42_001;
         // Storage of the most recent sleep value
-        AtomicLong sleepValue = new AtomicLong(NO_SLEEP_VALUE);
+        AtomicLong sleepValue = new AtomicLong(noSleepValue);
         Sleeper sleeper = value -> sleepValue.set(value);
 
         mojo.waitAfterFailure(0, Duration.ofSeconds(0), sleeper);
-        assertEquals(NO_SLEEP_VALUE, sleepValue.get());
+        assertEquals(noSleepValue, sleepValue.get());
 
         mojo.waitAfterFailure(1, Duration.ofSeconds(0), sleeper);
-        assertEquals(NO_SLEEP_VALUE, sleepValue.get());
+        assertEquals(noSleepValue, sleepValue.get());
 
         mojo.waitAfterFailure(0, Duration.ofSeconds(1), sleeper);
         assertEquals(1000, sleepValue.get());
@@ -243,10 +242,10 @@ public class JarsignerSignMojoRetryTest {
         mojo.waitAfterFailure(Integer.MAX_VALUE, Duration.ofSeconds(100), sleeper);
         assertEquals(100_000, sleepValue.get());
 
-        sleepValue.set(NO_SLEEP_VALUE); // "reset" sleep value
+        sleepValue.set(noSleepValue); // "reset" sleep value
         mojo.waitAfterFailure(Integer.MIN_VALUE, Duration.ofSeconds(100), sleeper);
         // Make sure sleep has not been invoked, should be the "reset" value
-        assertEquals(NO_SLEEP_VALUE, sleepValue.get());
+        assertEquals(noSleepValue, sleepValue.get());
 
         // Testing the attempt limit used in exponential function. Will return a odd value (2^20).
         mojo.waitAfterFailure(10000, Duration.ofDays(356), sleeper);

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -51,7 +51,11 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -65,8 +69,8 @@ public class JarsignerSignMojoTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     private Locale originalLocale;
-    private MavenProject project = mock(MavenProject.class);
-    private JarSigner jarSigner = mock(JarSigner.class);
+    MavenProject project = mock(MavenProject.class);
+    JarSigner jarSigner = mock(JarSigner.class);
     private File projectDir;
     private Map<String, String> configuration = new LinkedHashMap<>();
     private Log log;

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -42,7 +42,7 @@ import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERRO
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -40,7 +40,11 @@ import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -28,7 +28,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.maven.plugins.jarsigner.TsaSelector.TsaServer;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+
 
 public class TsaSelectorTest {
     private static final String[] EMPTY = new String[0];


### PR DESCRIPTION
The tests fail during set up in `MojoTestCreator`

```
         T mojo = clazz.getDeclaredConstructor(parameterTypes).newInstance();
        setDefaultValues(mojo);
```

fails with

> java.lang.IllegalArgumentException: InputStream cannot be null

	at java.xml/javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:118)
	at org.apache.maven.plugins.jarsigner.PluginXmlParser.getMojoDefaultConfiguration(PluginXmlParser.java:49)
	at org.apache.maven.plugins.jarsigner.MojoTestCreator.setDefaultValues(MojoTestCreator.java:160)
	at org.apache.maven.plugins.jarsigner.MojoTestCreator.configure(MojoTestCreator.java:93)
