### PR TITLE
Fix typos, grammar, and awkward phrasing in site documentation

### DIFF
--- a/src/site/apt/examples/sign-and-verify-project.apt.vm
+++ b/src/site/apt/examples/sign-and-verify-project.apt.vm
@@ -64,6 +64,6 @@ Sign and verify a project
 </project>
 +-----------------+
 
-  Note: The sign goal requires at least the alias to use for signing. This alias
+  <<Note:>> The sign goal requires at least the alias to use for signing. This alias
   can be passed using the command line like <<<-Djarsigner.alias="Alias Name">>>
   or set as a property in the <<<settings.xml>>> file when not configured in the POM.

--- a/src/site/apt/examples/sign-and-verify-project.apt.vm
+++ b/src/site/apt/examples/sign-and-verify-project.apt.vm
@@ -64,6 +64,6 @@ Sign and verify a project
 </project>
 +-----------------+
 
-  <<Note:>> The sign goal requires at least the alias to use for signing. This alias
-  can be passed using the command line like <<<-Djarsigner.alias="Alias Name">>>
+  <<Note:>> The sign goal requires the alias to use for signing. This alias
+  can be passed on the command line with <<<-Djarsigner.alias="Alias Name">>>
   or set as a property in the <<<settings.xml>>> file when not configured in the POM.

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -126,4 +126,4 @@ mvn ... -Djarsigner.skip=true
 
 * How to use encrypted password
 
-  Since version 1.3, you can pass to the plugin some password encrypted by the maven encryption mechanism.
+  Since version 1.3, you can pass passwords encrypted by the Maven encryption mechanism to the plugin.

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -61,7 +61,7 @@ under the License.
         <question>Why is there a problem on Windows when I sign an artifact and then run the assembly plugin?</question>
         <answer>
           <p>
-            To fix the problem, just move the assembly execution so it comes <strong>after</strong> the jarsigner execution in the pom.
+            To fix the problem, just move the assembly execution so it comes <strong>after</strong> the jarsigner execution in the POM.
           </p>
           <p>
             More details can be found in <a href="https://issues.apache.org/jira/browse/MJARSIGNER-13">MJARSIGNER-13</a>.

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -29,7 +29,7 @@ under the License.
      <question>What is Jarsigner?</question>
      <answer>
        <p>
-         You can read more about this tool in the offical guide:
+         You can read more about this tool in the official guide:
          <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/jarsigner.html">jarsigner - JAR Signing and Verification Tool</a>.
        </p>
      </answer>
@@ -58,13 +58,13 @@ under the License.
      </answer>
    </faq>
    <faq id="sign_and_assembly">
-        <question>Why if I want to sign an artifact and then assembly there is some problem under windows?</question>
+        <question>Why is there a problem on Windows when I sign an artifact and then run the assembly plugin?</question>
         <answer>
           <p>
             To fix the problem, just move the assembly execution so it comes <strong>after</strong> the jarsigner execution in the pom.
           </p>
           <p>
-           The whole story of the problem can be found in <a href="https://issues.apache.org/jira/browse/MJARSIGNER-13">MJARSIGNER-13</a> issue.
+            More details can be found in <a href="https://issues.apache.org/jira/browse/MJARSIGNER-13">MJARSIGNER-13</a>.
           </p>
         </answer>
       </faq>


### PR DESCRIPTION
Fixes across 3 files:

Typo:
- faq.fml: offical -> official

Grammar:
- faq.fml: fixed ungrammatical FAQ question about Windows/assembly

Awkward phrasing:
- faq.fml: The whole story -> More details can be found in
- usage.apt.vm: fixed awkward word order in encrypted password sentence
- sign-and-verify-project.apt.vm: Note: -> <<Note:>> for consistent Maven docs rendering