### PR TITLE
Guard against null passwords in getCommandlineInfo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -373,7 +373,9 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
         }
 
         String commandLineInfo = commandLine.toString();
-        commandLineInfo = StringUtils.replace(commandLineInfo, this.storepass, "'*****'");
+        if (this.storepass != null) {
+            commandLineInfo = StringUtils.replace(commandLineInfo, this.storepass, "'*****'");
+        }
         return commandLineInfo;
     }
 

--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -247,7 +247,7 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     protected String getCommandlineInfo(final Commandline commandLine) {
         String commandLineInfo = commandLine != null ? commandLine.toString() : null;
 
-        if (commandLineInfo != null) {
+        if (commandLineInfo != null && this.keypass != null) {
             commandLineInfo = StringUtils.replace(commandLineInfo, this.keypass, "'*****'");
         }
 

--- a/src/site/apt/examples/sign-and-verify-project.apt.vm
+++ b/src/site/apt/examples/sign-and-verify-project.apt.vm
@@ -64,6 +64,6 @@ Sign and verify a project
 </project>
 +-----------------+
 
-  Note: The sign goal requires at least the alias to use for signing. This alias
+  <<Note:>> The sign goal requires at least the alias to use for signing. This alias
   can be passed using the command line like <<<-Djarsigner.alias="Alias Name">>>
   or set as a property in the <<<settings.xml>>> file when not configured in the POM.

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -126,4 +126,4 @@ mvn ... -Djarsigner.skip=true
 
 * How to use encrypted password
 
-  Since version 1.3, you can pass to the plugin some password encrypted by the maven encryption mechanism.
+  Since version 1.3, you can pass passwords encrypted by the Maven encryption mechanism to the plugin.

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -29,7 +29,7 @@ under the License.
      <question>What is Jarsigner?</question>
      <answer>
        <p>
-         You can read more about this tool in the offical guide:
+         You can read more about this tool in the official guide:
          <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/jarsigner.html">jarsigner - JAR Signing and Verification Tool</a>.
        </p>
      </answer>
@@ -58,13 +58,13 @@ under the License.
      </answer>
    </faq>
    <faq id="sign_and_assembly">
-        <question>Why if I want to sign an artifact and then assembly there is some problem under windows?</question>
+        <question>Why is there a problem on Windows when I sign an artifact and then run the assembly plugin?</question>
         <answer>
           <p>
             To fix the problem, just move the assembly execution so it comes <strong>after</strong> the jarsigner execution in the pom.
           </p>
           <p>
-           The whole story of the problem can be found in <a href="https://issues.apache.org/jira/browse/MJARSIGNER-13">MJARSIGNER-13</a> issue.
+            More details can be found in <a href="https://issues.apache.org/jira/browse/MJARSIGNER-13">MJARSIGNER-13</a>.
           </p>
         </answer>
       </faq>

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -32,7 +32,9 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
 import org.apache.maven.shared.jarsigner.JarSignerUtil;
+import org.apache.maven.shared.utils.cli.Commandline;
 import org.apache.maven.shared.utils.cli.javatool.JavaToolException;
+import org.apache.maven.shared.utils.cli.shell.Shell;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.junit.After;
@@ -53,6 +55,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -183,6 +186,22 @@ public class JarsignerSignMojoTest {
         mojo.execute();
 
         verify(jarSigner, never()).execute(any()); // Should not try to sign anything
+    }
+
+    /**
+     * Verifies that {@code getCommandlineInfo} does not throw when
+     * {@code keypass} is {@code null} (the default).
+     */
+    @Test
+    public void testGetCommandlineInfoWithNullKeypass() throws Exception {
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+        Shell shell = new Shell();
+        Commandline cmd = new Commandline(shell);
+        cmd.setExecutable("jarsigner");
+        cmd.addArguments("my-project.jar", "myalias");
+
+        String info = mojo.getCommandlineInfo(cmd);
+        assertNotNull(info);
     }
 
     /** Make sure that when skip is configured the Mojo will not process anything */

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -28,6 +28,8 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerVerifyRequest;
+import org.apache.maven.shared.utils.cli.Commandline;
+import org.apache.maven.shared.utils.cli.shell.Shell;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,6 +44,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -131,6 +134,22 @@ public class JarsignerVerifyMojoTest {
         assertThat(
                 mojoException.getMessage(),
                 containsString(RESULT_ERROR.getCommandline().toString()));
+    }
+
+    /**
+     * Verifies that {@code getCommandlineInfo} does not throw when
+     * {@code storepass} is {@code null} (the default).
+     */
+    @Test
+    public void testGetCommandlineInfoWithNullStorepass() throws Exception {
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+        Shell shell = new Shell();
+        Commandline cmd = new Commandline(shell);
+        cmd.setExecutable("jarsigner");
+        cmd.addArguments("my-project.jar", "myalias");
+
+        String info = mojo.getCommandlineInfo(cmd);
+        assertNotNull(info);
     }
 
     /** When setting errorWhenNotSigned, for file that has existing signing (should not fail) */


### PR DESCRIPTION
Fixes #151

Added null guards before calling StringUtils.replace() in both AbstractJarsignerMojo.getCommandlineInfo() (storepass) and JarsignerSignMojo.getCommandlineInfo() (keypass), with regression tests for both mojos.