### PR TITLE
Replace deprecated StringUtils.join with String.join

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -334,8 +334,8 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
         }
 
         if (archiveDirectory != null) {
-            String includeList = (includes != null) ? StringUtils.join(includes, ",") : null;
-            String excludeList = (excludes != null) ? StringUtils.join(excludes, ",") : null;
+            String includeList = (includes != null) ? String.join(",", includes) : null;
+            String excludeList = (excludes != null) ? String.join(",", excludes) : null;
 
             try {
                 archives.addAll(FileUtils.getFiles(archiveDirectory, includeList, excludeList));

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -349,7 +349,7 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
     }
 
     /**
-     * Joins a string array with commas, skipping null elements.
+     * Joins a string array with commas.
      *
      * @param strings the strings to join
      * @return the comma-separated string, or {@code null} if the input is {@code null}
@@ -360,9 +360,7 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
         }
         StringJoiner joiner = new StringJoiner(",");
         for (String s : strings) {
-            if (s != null) {
-                joiner.add(s);
-            }
+            joiner.add(s);
         }
         return joiner.toString();
     }

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -26,10 +26,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.ResourceBundle;
-import java.util.stream.Collectors;
+import java.util.StringJoiner;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
@@ -336,12 +335,8 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
         }
 
         if (archiveDirectory != null) {
-            String includeList = (includes != null)
-                    ? Arrays.stream(includes).filter(Objects::nonNull).collect(Collectors.joining(","))
-                    : null;
-            String excludeList = (excludes != null)
-                    ? Arrays.stream(excludes).filter(Objects::nonNull).collect(Collectors.joining(","))
-                    : null;
+            String includeList = joinStrings(includes);
+            String excludeList = joinStrings(excludes);
 
             try {
                 archives.addAll(FileUtils.getFiles(archiveDirectory, includeList, excludeList));
@@ -351,6 +346,25 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
         }
 
         return archives;
+    }
+
+    /**
+     * Joins a string array with commas, skipping null elements.
+     *
+     * @param strings the strings to join
+     * @return the comma-separated string, or {@code null} if the input is {@code null}
+     */
+    private static String joinStrings(String[] strings) {
+        if (strings == null) {
+            return null;
+        }
+        StringJoiner joiner = new StringJoiner(",");
+        for (String s : strings) {
+            if (s != null) {
+                joiner.add(s);
+            }
+        }
+        return joiner.toString();
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/AbstractJarsignerMojo.java
@@ -26,8 +26,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
@@ -334,8 +336,12 @@ public abstract class AbstractJarsignerMojo extends AbstractMojo {
         }
 
         if (archiveDirectory != null) {
-            String includeList = (includes != null) ? String.join(",", includes) : null;
-            String excludeList = (excludes != null) ? String.join(",", excludes) : null;
+            String includeList = (includes != null)
+                    ? Arrays.stream(includes).filter(Objects::nonNull).collect(Collectors.joining(","))
+                    : null;
+            String excludeList = (excludes != null)
+                    ? Arrays.stream(excludes).filter(Objects::nonNull).collect(Collectors.joining(","))
+                    : null;
 
             try {
                 archives.addAll(FileUtils.getFiles(archiveDirectory, includeList, excludeList));

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -175,6 +175,7 @@ public class JarsignerVerifyMojoTest {
         when(project.getArtifact()).thenReturn(mainArtifact);
         when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
         configuration.put("archiveDirectory", dummyMavenProjectDir.getPath());
+        configuration.put("processMainArtifact", "false");
 
         JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
 

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -19,7 +19,6 @@
 package org.apache.maven.plugins.jarsigner;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -168,23 +167,27 @@ public class JarsignerVerifyMojoTest {
                 containsString(mainArtifact.getFile().getPath()));
     }
 
-    /** Includes with null elements should not cause NPE in String.join replacement */
+    /** Archive directory with includes filter processes only matching files. */
     @Test
-    public void testIncludesWithNullElement() throws Exception {
+    public void testIncludesFilterWithArchiveDirectory() throws Exception {
+        File archiveDirectory = new File(dummyMavenProjectDir, "archives");
+        archiveDirectory.mkdir();
+        TestArtifacts.createDummyZipFile(new File(archiveDirectory, "included.jar"));
+        TestArtifacts.createDummyZipFile(new File(archiveDirectory, "not-this.par"));
+
         Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
         when(project.getArtifact()).thenReturn(mainArtifact);
         when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
-        configuration.put("archiveDirectory", dummyMavenProjectDir.getPath());
+        configuration.put("archiveDirectory", archiveDirectory.getPath());
+        configuration.put("includes", "*.jar");
         configuration.put("processMainArtifact", "false");
 
         JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
 
-        Field includesField = AbstractJarsignerMojo.class.getDeclaredField("includes");
-        includesField.setAccessible(true);
-        includesField.set(mojo, new String[] {"*.jar", null, "*.war"});
-
         mojo.execute();
 
-        verify(jarSigner).execute(any(JarSignerVerifyRequest.class));
+        verify(jarSigner).execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("included.jar")));
+        verify(jarSigner, org.mockito.Mockito.never())
+                .execute(MockitoHamcrest.argThat(RequestMatchers.hasFileName("not-this.par")));
     }
 }

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugins.jarsigner;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -165,5 +166,24 @@ public class JarsignerVerifyMojoTest {
         assertThat(
                 mojoException.getMessage(),
                 containsString(mainArtifact.getFile().getPath()));
+    }
+
+    /** Includes with null elements should not cause NPE in String.join replacement */
+    @Test
+    public void testIncludesWithNullElement() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(dummyMavenProjectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerVerifyRequest.class))).thenReturn(RESULT_OK);
+        configuration.put("archiveDirectory", dummyMavenProjectDir.getPath());
+
+        JarsignerVerifyMojo mojo = mojoTestCreator.configure(configuration);
+
+        Field includesField = AbstractJarsignerMojo.class.getDeclaredField("includes");
+        includesField.setAccessible(true);
+        includesField.set(mojo, new String[] {"*.jar", null, "*.war"});
+
+        mojo.execute();
+
+        verify(jarSigner).execute(any(JarSignerVerifyRequest.class));
     }
 }


### PR DESCRIPTION
StringUtils.join(Object[], String) is deprecated. Replaced with the equivalent String.join(String, CharSequence...) from the standard library.