### PR TITLE
Migrate test suite from JUnit 4 to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,9 +132,14 @@ under the License.
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoParallelTest.java
@@ -37,19 +37,19 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.isA;
@@ -59,8 +59,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JarsignerSignMojoParallelTest {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    private File folder;
 
     private MavenProject project = mock(MavenProject.class);
     private JarSigner jarSigner = mock(JarSigner.class);
@@ -70,9 +70,10 @@ public class JarsignerSignMojoParallelTest {
     private ExecutorService executor;
     private Log log;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        projectDir = folder.newFolder("dummy-project");
+        projectDir = new File(folder, "dummy-project");
+        projectDir.mkdir();
         configuration.put("processMainArtifact", "false");
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
@@ -82,12 +83,13 @@ public class JarsignerSignMojoParallelTest {
                 Executors.newSingleThreadExecutor(namedThreadFactory(getClass().getSimpleName()));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         executor.shutdown();
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30)
     public void test10Files2Parallel() throws Exception {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "2");
@@ -115,7 +117,8 @@ public class JarsignerSignMojoParallelTest {
         assertTrue(future.isDone());
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30)
     public void test10Files2Parallel3Hanging() throws Exception {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "2");
@@ -147,7 +150,8 @@ public class JarsignerSignMojoParallelTest {
         assertTrue(future.isDone());
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30)
     public void test10Files1Parallel() throws Exception {
         configuration.put("archiveDirectory", createArchives(10).getPath());
         configuration.put("threadCount", "1");
@@ -174,7 +178,8 @@ public class JarsignerSignMojoParallelTest {
         assertTrue(future.isDone());
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30)
     public void test10Files2ParallelOneFail() throws Exception {
         /*
         This tests relies on English language.

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
@@ -34,19 +34,18 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
 import org.apache.maven.shared.utils.cli.javatool.JavaToolResult;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.argThat;
@@ -57,8 +56,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JarsignerSignMojoRetryTest {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    private File folder;
 
     private Locale originalLocale;
     private MavenProject project = mock(MavenProject.class);
@@ -69,11 +68,12 @@ public class JarsignerSignMojoRetryTest {
     private Log log;
     private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
-        projectDir = folder.newFolder("dummy-project");
+        projectDir = new File(folder, "dummy-project");
+        projectDir.mkdir();
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
         log = mock(Log.class);
@@ -82,7 +82,7 @@ public class JarsignerSignMojoRetryTest {
         when(project.getArtifact()).thenReturn(mainArtifact);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         Locale.setDefault(originalLocale);
     }

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -35,11 +35,10 @@ import org.apache.maven.shared.jarsigner.JarSignerUtil;
 import org.apache.maven.shared.utils.cli.javatool.JavaToolException;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.hamcrest.MockitoHamcrest;
 
@@ -51,11 +50,11 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -66,8 +65,8 @@ import static org.mockito.Mockito.when;
 
 public class JarsignerSignMojoTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    private File folder;
 
     private Locale originalLocale;
     private MavenProject project = mock(MavenProject.class);
@@ -77,18 +76,19 @@ public class JarsignerSignMojoTest {
     private Log log;
     private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
-        projectDir = folder.newFolder("dummy-project");
+        projectDir = new File(folder, "dummy-project");
+        projectDir.mkdir();
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
         log = mock(Log.class);
         mojoTestCreator.setLog(log);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         Locale.setDefault(originalLocale);
     }
@@ -288,8 +288,8 @@ public class JarsignerSignMojoTest {
         File previouslySignedArchive =
                 TestArtifacts.createDummySignedJarFile(new File(archiveDirectory, "previously_signed_archive.jar"));
         assertTrue(
-                "previously_signed_archive.jar should be detected as a signed file before executing the Mojo",
-                JarSignerUtil.isArchiveSigned(previouslySignedArchive));
+                JarSignerUtil.isArchiveSigned(previouslySignedArchive),
+                "previously_signed_archive.jar should be detected as a signed file before executing the Mojo");
         TestArtifacts.createDummyZipFile(new File(archiveDirectory, "archive_to_exclude.jar"));
         TestArtifacts.createDummyZipFile(new File(archiveDirectory, "not_this.par"));
 

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTsaTest.java
@@ -31,18 +31,17 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerSignRequest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_ERROR;
 import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
@@ -51,8 +50,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JarsignerSignMojoTsaTest {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    private File folder;
 
     private Locale originalLocale;
     private MavenProject project = mock(MavenProject.class);
@@ -63,11 +62,12 @@ public class JarsignerSignMojoTsaTest {
     private Log log;
     private MojoTestCreator<JarsignerSignMojo> mojoTestCreator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         originalLocale = Locale.getDefault();
         Locale.setDefault(Locale.ENGLISH); // For English ResourceBundle to test log messages
-        projectDir = folder.newFolder("dummy-project");
+        projectDir = new File(folder, "dummy-project");
+        projectDir.mkdir();
         mojoTestCreator =
                 new MojoTestCreator<JarsignerSignMojo>(JarsignerSignMojo.class, project, projectDir, jarSigner);
         log = mock(Log.class);
@@ -76,7 +76,7 @@ public class JarsignerSignMojoTsaTest {
         when(project.getArtifact()).thenReturn(mainArtifact);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         Locale.setDefault(originalLocale);
     }

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerVerifyMojoTest.java
@@ -28,10 +28,9 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.jarsigner.JarSigner;
 import org.apache.maven.shared.jarsigner.JarSignerVerifyRequest;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.hamcrest.MockitoHamcrest;
 
@@ -40,10 +39,10 @@ import static org.apache.maven.plugins.jarsigner.TestJavaToolResults.RESULT_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -52,8 +51,8 @@ import static org.mockito.Mockito.when;
 
 public class JarsignerVerifyMojoTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    private File folder;
 
     private MavenProject project = mock(MavenProject.class);
     private JarSigner jarSigner = mock(JarSigner.class);
@@ -62,9 +61,10 @@ public class JarsignerVerifyMojoTest {
     private Log log;
     private MojoTestCreator<JarsignerVerifyMojo> mojoTestCreator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        dummyMavenProjectDir = folder.newFolder("dummy-project");
+        dummyMavenProjectDir = new File(folder, "dummy-project");
+        dummyMavenProjectDir.mkdir();
         mojoTestCreator = new MojoTestCreator<JarsignerVerifyMojo>(
                 JarsignerVerifyMojo.class, project, dummyMavenProjectDir, jarSigner);
         log = mock(Log.class);

--- a/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/TsaSelectorTest.java
@@ -26,10 +26,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.maven.plugins.jarsigner.TsaSelector.TsaServer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TsaSelectorTest {
     private static final String[] EMPTY = new String[0];
@@ -81,7 +82,8 @@ public class TsaSelectorTest {
         assertNull(tsaServer.getTsaDigestAlg());
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(30)
     public void testMultiThreadedScenario() throws InterruptedException {
         executor = Executors.newFixedThreadPool(2);
 


### PR DESCRIPTION
## Summary
- Migrate all 6 JUnit 4 test files to JUnit 5 (Jupiter): `org.junit.Test`/`Before`/`After`/`Rule` -> Jupiter equivalents, `TemporaryFolder` -> `@TempDir`, `@Test(timeout=...)` -> `@Timeout`, `org.junit.Assert` -> `org.junit.jupiter.api.Assertions` (reordering the one message-first `assertTrue` call to match the new signature).
- Replace the `junit:junit` dependency with `org.junit.jupiter:junit-jupiter`, version-managed via the `junit-bom` import already provided by `maven-parent` (49), matching the pattern used in the sibling `maven-jlink-plugin`.
- Add an explicit `org.hamcrest:hamcrest:3.0` test dependency: JUnit 4 previously pulled in `hamcrest-core` transitively, which this module relies on directly (`CoreMatchers`, `MatcherAssert`, `TypeSafeMatcher`, `Description` in `RequestMatchers.java` and several tests).
- No load-bearing JUnit 4 usage was found (no `AbstractMojoTestCase`/`MojoRule`, no Ant `<junit>` task, no `suite()` method), so this is a full, mechanical migration with no leftover JUnit 4 files.

## Test plan
- [x] `mvn -B test` before migration: `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` (surefire auto-detected `JUnit4Provider`)
- [x] `mvn -B test` after migration: `Tests run: 48, Failures: 0, Errors: 0, Skipped: 0` (surefire auto-detected `JUnitPlatformProvider`, confirming real JUnit 5 execution)
- [x] `mvn -q -B spotless:apply` / `mvn -q -B spotless:check` clean
- [ ] CI green

Generated-by: Claude Opus 5 (1M context)