### PR TITLE
Fix misleading tsapolicyid warning when no TSA servers configured

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -287,7 +287,8 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
         if (tsa.length > 0 && tsacert.length > 0) {
             getLog().warn(getMessage("warnUsageTsaAndTsacertSimultaneous"));
         }
-        if (tsapolicyid.length > tsa.length || tsapolicyid.length > tsacert.length) {
+        if ((tsa.length > 0 || tsacert.length > 0)
+                && (tsapolicyid.length > tsa.length || tsapolicyid.length > tsacert.length)) {
             getLog().warn(getMessage("warnUsageTsapolicyidTooMany", tsapolicyid.length, tsa.length, tsacert.length));
         }
         if (tsa.length > 1 && maxTries == 1) {

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoTest.java
@@ -445,6 +445,50 @@ public class JarsignerSignMojoTest {
         verify(log).info(contains("1 archive(s) processed"));
     }
 
+    /**
+     * Test that no misleading "Too many OIDs" warning is emitted when tsapolicyid is configured
+     * but neither tsa nor tsacert are configured. See
+     * <a href="https://github.com/apache/maven-jarsigner-plugin/issues/149">issue #149</a>.
+     */
+    @Test
+    public void testTsapolicyidWarningNotEmittedWhenNoTsaConfigured() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        // Configure tsapolicyid but leave tsa and tsacert empty (not configured)
+        configuration.put("tsapolicyid", "1.3.6.1.4.1.4146.2.3.1.2");
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        // The misleading "Too many OIDs" warning must not be emitted
+        verify(log, never()).warn(contains("Too many"));
+    }
+
+    /**
+     * Test that the "Too many OIDs" warning IS emitted when tsapolicyid has more entries than
+     * tsa, and tsa is actually configured.
+     */
+    @Test
+    public void testTsapolicyidWarningEmittedWhenMoreOidsThanTsaServers() throws Exception {
+        Artifact mainArtifact = TestArtifacts.createJarArtifact(projectDir, "my-project.jar");
+        when(project.getArtifact()).thenReturn(mainArtifact);
+        when(jarSigner.execute(any(JarSignerSignRequest.class))).thenReturn(RESULT_OK);
+
+        // Configure one tsa server but two tsapolicyid entries
+        configuration.put("tsa", "http://timestamp.example.com");
+        configuration.put("tsapolicyid", "1.3.6.1.4.1.4146.2.3.1.2,2.16.840.1.114412.7.1");
+
+        JarsignerSignMojo mojo = mojoTestCreator.configure(configuration);
+
+        mojo.execute();
+
+        // The "Too many OIDs" warning should be emitted
+        verify(log).warn(contains("Too many"));
+    }
+
     /** Test what is logged when verbose=false */
     @Test
     public void testLoggingVerboseFalse() throws Exception {


### PR DESCRIPTION
Fixes #149

When neither `tsa` nor `tsacert` are configured and the user has set `tsapolicyid`, the validation check at `JarsignerSignMojo.java:290` produces a misleading warning:

```
Too many (1) number of OIDs given, but only 0 and 0 TSA URL and TSA certificate alias, respectively
```

The real problem is that no TSA servers are configured at all, so all OIDs will be silently ignored regardless.

**Fix:** Guard the count comparison with a check that at least one TSA source is configured before emitting the warning.

**Tests added:**
- `testTsapolicyidWarningNotEmittedWhenNoTsaConfigured` - verifies no misleading warning when tsapolicyid is set but no TSA servers are configured
- `testTsapolicyidWarningEmittedWhenMoreOidsThanTsaServers` - verifies the warning IS emitted when there are more OIDs than TSA servers and TSA is configured