### PR TITLE
Fix waitAfterFailure negative exponent for negative attempt values

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojo.java
@@ -413,7 +413,8 @@ public class JarsignerSignMojo extends AbstractJarsignerMojo {
     /** Package private for testing */
     void waitAfterFailure(int attempt, Duration maxRetryDelay, Sleeper sleeper) throws MojoExecutionException {
         // Use attempt as exponent in the exponential function, but limit it to avoid too big values.
-        int exponentAttempt = Math.min(attempt, MAX_WAIT_EXPONENT_ATTEMPT);
+        // Clamp to >= 0 to avoid fractional delays for negative attempt values.
+        int exponentAttempt = Math.max(0, Math.min(attempt, MAX_WAIT_EXPONENT_ATTEMPT));
         long delayMillis = (long) (Duration.ofSeconds(1).toMillis() * Math.pow(2, exponentAttempt));
         delayMillis = Math.min(delayMillis, maxRetryDelay.toMillis());
         if (delayMillis > 0) {

--- a/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
+++ b/src/test/java/org/apache/maven/plugins/jarsigner/JarsignerSignMojoRetryTest.java
@@ -245,10 +245,14 @@ public class JarsignerSignMojoRetryTest {
         mojo.waitAfterFailure(Integer.MAX_VALUE, Duration.ofSeconds(100), sleeper);
         assertEquals(100_000, sleepValue.get());
 
+        // Negative attempt values should be treated as 0 (first attempt), sleeping 2^0 = 1 second.
         sleepValue.set(noSleepValue); // "reset" sleep value
         mojo.waitAfterFailure(Integer.MIN_VALUE, Duration.ofSeconds(100), sleeper);
-        // Make sure sleep has not been invoked, should be the "reset" value
-        assertEquals(noSleepValue, sleepValue.get());
+        assertEquals(1000, sleepValue.get());
+
+        sleepValue.set(noSleepValue); // "reset" sleep value
+        mojo.waitAfterFailure(-1, Duration.ofSeconds(100), sleeper);
+        assertEquals(1000, sleepValue.get());
 
         // Testing the attempt limit used in exponential function. Will return a odd value (2^20).
         mojo.waitAfterFailure(10000, Duration.ofDays(356), sleeper);


### PR DESCRIPTION
Fixes #152

## Problem

`waitAfterFailure()` uses `Math.min(attempt, MAX_WAIT_EXPONENT_ATTEMPT)` to clamp the exponent for the exponential backoff delay. For negative `attempt` values (e.g. `Integer.MIN_VALUE`), this produces a negative exponent, resulting in `Math.pow(2, -2147483648)` which evaluates to 0.0 — no delay at all.

## Fix

Clamp the exponent to >= 0 using `Math.max(0, Math.min(attempt, MAX_WAIT_EXPONENT_ATTEMPT))`. Negative attempt values are now treated as attempt 0 (2^0 = 1 second delay).

## Changes

- `JarsignerSignMojo.java:416`: Added `Math.max(0, ...)` to clamp exponent
- `JarsignerSignMojoRetryTest.java`: Updated test to assert that `Integer.MIN_VALUE` and `-1` produce a 1-second delay instead of no delay
